### PR TITLE
Fix/default node symbol

### DIFF
--- a/src/components/Graph/index.js
+++ b/src/components/Graph/index.js
@@ -102,7 +102,7 @@ export default class Graph extends React.Component {
     /**
      * Handles d3 drag 'start' event.
      */
-    _onDragStart = () => !this.state.config.staticGraph && this.state.simulation.stop();
+    _onDragStart = () => this.pauseSimulation();
 
     /**
      * Sets nodes and links highlighted value.

--- a/src/components/Graph/index.js
+++ b/src/components/Graph/index.js
@@ -120,7 +120,7 @@ export default class Graph extends React.Component {
             });
         }
 
-        this.setState(this.state || {});
+        this._tick();
     }
 
     /**
@@ -191,7 +191,7 @@ export default class Graph extends React.Component {
             // @TODO: hardcoded alpha target
             this.state.simulation.alphaTarget(0.08).restart();
 
-            this.setState(this.state || {});
+            this._tick();
         }
     }
 
@@ -304,7 +304,7 @@ export default class Graph extends React.Component {
             Utils.throwErr(this.constructor.name, ERRORS.STATIC_GRAPH_DATA_UPDATE);
         }
 
-        const configUpdated = Utils.isDeepEqual(nextProps.config, this.state.config);
+        const configUpdated = !Utils.isDeepEqual(nextProps.config, this.state.config);
         const state = newGraphElements ? this._initializeGraphState(nextProps.data) : this.state;
         const config = Utils.merge(DEFAULT_CONFIG, nextProps.config || {});
 

--- a/src/components/Node/helper.js
+++ b/src/components/Node/helper.js
@@ -12,7 +12,7 @@ import CONST from './const';
  * of d3 symbol.<br/>
  * {@link https://github.com/d3/d3-shape/blob/master/README.md#symbol}
  * @param  {string} typeName - the string that specifies the symbol type (should be one of {@link #node-symbol-type|node.symbolType}).
- * @return {Object} concrete instance of d3 symbol.
+ * @return {Object} concrete instance of d3 symbol (defaults to circle).
  * @memberof Node/helper
  */
 function _convertTypeToD3Symbol(typeName) {
@@ -32,7 +32,7 @@ function _convertTypeToD3Symbol(typeName) {
         case CONST.SYMBOLS.WYE:
             return d3.symbolWye;
         default:
-            return d3.symbolTriangle;
+            return d3.symbolCircle;
     }
 }
 


### PR DESCRIPTION
- Default node symbol is circle as it should be;
- Small :bug: in `configUpdated` flag on `Graph/index.js` `componentWillReceiveProps`. 