### PR TITLE
Fix typo node.stype -> node.symbolType

### DIFF
--- a/src/components/Graph/helper.jsx
+++ b/src/components/Graph/helper.jsx
@@ -171,7 +171,7 @@ function _buildNodeProps(node, config, nodeCallbacks, someNodeHighlighted, trans
         size: nodeSize * t,
         stroke,
         strokeWidth: strokeWidth * t,
-        type: node.type || config.node.symbolType
+        type: node.symbolType || config.node.symbolType
     };
 }
 


### PR DESCRIPTION
`symbolType` prop was not passing down to node component.