### PR TITLE
Fix/set initial static graph

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig is awesome: http://EditorConfig.org
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{js}]
+charset = utf-8
+
+[*.js]
+indent_style = space
+indent_size = 4
+
+[Makefile]
+indent_style = tab
+
+[{package.json,package-lock.json,yarn.lock,.travis.yml}]
+indent_style = space
+indent_size = 4

--- a/.eslintrc.test.config.js
+++ b/.eslintrc.test.config.js
@@ -1,0 +1,31 @@
+module.exports = {
+    "extends": [ "plugin:jest/recommended" ],
+    "globals": {
+        "document": true,
+        "Reflect": true,
+        "window": true
+    },
+    "parser": "babel-eslint",
+    "parserOptions": {
+        "ecmaVersion": 6,
+        "ecmaFeatures": {
+            "jsx": true
+        }
+    },
+    "plugins": [
+        "standard",
+        "promise",
+        "react",
+        "jest"
+    ],
+    "rules": {
+        "jest/no-disabled-tests": "warn",
+        "jest/no-focused-tests": "error",
+        "jest/no-identical-title": "error",
+        "jest/valid-expect": "error",
+        "max-len": ["error", 180, 4, { "ignoreComments": true }]
+    },
+    "env": {
+        "jest/globals": true
+    }
+};

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # react-d3-graph &middot; [![Build Status](https://travis-ci.com/danielcaldas/react-d3-graph.svg?token=fb6uSENok5Y3gSSi5yjE&branch=master)](https://travis-ci.com/danielcaldas/react-d3-graph) [![npm version](https://img.shields.io/badge/npm-v0.2.1-blue.svg)](https://www.npmjs.com/package/react-d3-graph) [![npm stats](https://img.shields.io/badge/downloads->600-brightgreen.svg)](https://npm-stat.com/) [![probot enabled](https://img.shields.io/badge/probot:stale-enabled-yellow.svg)](https://probot.github.io/)
+[:book:](https://danielcaldas.github.io/react-d3-graph/docs/index.html)
 
 ### *Interactive and configurable graphs with react and d3 effortlessly*
 
 ![react-d3-graph gif sample](https://github.com/danielcaldas/react-d3-graph/blob/master/sandbox/rd3g.gif?raw=true)
 
 ## Playground
-Here a live playground (https://danielcaldas.github.io/react-d3-graph/sandbox/index.html) page where you can interactively config your own graph, and generate a ready to use configuration! :sunglasses:
+[Here a live playground](https://danielcaldas.github.io/react-d3-graph/sandbox/index.html) page where you can interactively config your own graph, and generate a ready to use configuration! :sunglasses:
 
-## Documentation
+## Documentation :book:
 Full documentation [here](https://danielcaldas.github.io/react-d3-graph/docs/index.html).
 
 ## Compatibility

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
         "docs": "npm run docs:lint && node_modules/documentation/bin/documentation.js build src/**/*.js -f html -o gen-docs && node_modules/documentation/bin/documentation.js build src/**/*.js -f md > gen-docs/DOCUMENTATION.md",
         "docs:lint": "node_modules/documentation/bin/documentation.js lint src/**/*.js",
         "docs:watch": "node_modules/documentation/bin/documentation.js build src/**/*.js -f html -o gen-docs --watch",
-        "lint": "node_modules/eslint/bin/eslint.js --config=.eslintrc.js \"src/**/*.js*\"",
+        "lint": "npm run lint:src && npm run lint:test",
+        "lint:src": "node_modules/eslint/bin/eslint.js --config=.eslintrc.js \"src/**/*.js*\"",
+        "lint:test": "node_modules/eslint/bin/eslint.js --config=.eslintrc.test.config.js \"test/**/*.test.js\"",
         "test": "jest --verbose --coverage",
         "test:clean": "jest --no-cache --updateSnapshot --verbose --coverage",
         "test:watch": "jest --verbose --watchAll"
@@ -39,6 +41,7 @@
         "documentation": "5.3.2",
         "eslint": "3.18.0",
         "eslint-config-recommended": "1.5.0",
+        "eslint-plugin-jest": "21.2.0",
         "eslint-plugin-promise": "3.5.0",
         "eslint-plugin-standard": "2.1.1",
         "html-webpack-plugin": "2.30.1",

--- a/sandbox/Sandbox.jsx
+++ b/sandbox/Sandbox.jsx
@@ -29,27 +29,11 @@ export default class Sandbox extends React.Component {
         this.uiSchema = uiSchema;
 
         this.state = {
-            config: defaultConfig,
+            config: {}, // Override initial configs here. e.g: {staticGraph: true}
             generatedConfig: {},
             schema,
-            data: { nodes: this._decorateGraphNodesWithInitialPositioning(data.nodes), links: data.links }
+            data
         };
-    }
-
-    /**
-     * This function decorates nodes and links with positions. The motivation
-     * for this function its to set `config.staticGraph` to true on the first render
-     * call, and to get nodes and links statically set to their initial positions.
-     * @param  {Object} nodes nodes and links with minimalist structure
-     * @return {Object} the graph where now nodes containing (x,y) coords.
-     */
-    _decorateGraphNodesWithInitialPositioning = (nodes) => {
-        return nodes.map(n => ({
-            id: n.id,
-            x: Math.floor(Math.random() * 500),
-            y: Math.floor(Math.random() * 500),
-            symbolType: n.symbolType || 'circle'
-        }));
     }
 
     onClickNode = (id) => window.alert(`Clicked node ${id}`);
@@ -137,7 +121,7 @@ export default class Sandbox extends React.Component {
 
     /**
      * ==============================================================
-     * The methods below (**besides render method) is Sandbox specific it will not
+     * The methods below (besides render method) is Sandbox specific it will not
      * be usefull in any way to your application in terms
      * of integrating react-d3-graph in your app.
      * ==============================================================
@@ -201,11 +185,36 @@ export default class Sandbox extends React.Component {
         });
     }
 
+    /**
+     * This function decorates nodes and links with positions. The motivation
+     * for this function its to set `config.staticGraph` to true on the first render
+     * call, and to get nodes and links statically set to their initial positions.
+     * @param  {Object} nodes nodes and links with minimalist structure.
+     * @return {Object} the graph where now nodes containing (x,y) coords.
+     */
+    decorateGraphNodesWithInitialPositioning = (nodes) => {
+        return nodes.map(n => ({
+            id: n.id,
+            x: Math.floor(Math.random() * 500),
+            y: Math.floor(Math.random() * 500),
+            symbolType: n.symbolType || 'circle'
+        }));
+    }
+
     render() {
+        // This does not happens in this sandbox scenario running time, but if we set staticGraph config
+        // to true in the constructor
+        const data = this.state.config.staticGraph ?
+        {
+            nodes: this.decorateGraphNodesWithInitialPositioning(this.state.data.nodes),
+            links: this.state.data.links
+        }
+        : this.state.data;
+
         const graphProps = {
             id: 'graph',
-            data: this.state.data,
-            config: Object.assign(this.state.config, {staticGraph: true}),
+            data,
+            config: this.state.config,
             onClickNode: this.onClickNode,
             onClickLink: this.onClickLink,
             onMouseOverNode: this.onMouseOverNode,
@@ -216,6 +225,7 @@ export default class Sandbox extends React.Component {
             cursor: this.state.config.staticGraph ? 'not-allowed' : 'pointer'
         };
 
+        // @TODO: Only show configs that differ from default ones in "Your config" box
         return (
             <div className='container'>
                 <div className='container__graph'>

--- a/sandbox/Sandbox.jsx
+++ b/sandbox/Sandbox.jsx
@@ -32,8 +32,24 @@ export default class Sandbox extends React.Component {
             config: defaultConfig,
             generatedConfig: {},
             schema,
-            data
+            data: { nodes: this._decorateGraphNodesWithInitialPositioning(data.nodes), links: data.links }
         };
+    }
+
+    /**
+     * This function decorates nodes and links with positions. The motivation
+     * for this function its to set `config.staticGraph` to true on the first render
+     * call, and to get nodes and links statically set to their initial positions.
+     * @param  {Object} nodes nodes and links with minimalist structure
+     * @return {Object} the graph where now nodes containing (x,y) coords.
+     */
+    _decorateGraphNodesWithInitialPositioning = (nodes) => {
+        return nodes.map(n => ({
+            id: n.id,
+            x: Math.floor(Math.random() * 500),
+            y: Math.floor(Math.random() * 500),
+            symbolType: n.symbolType || 'circle'
+        }));
     }
 
     onClickNode = (id) => window.alert(`Clicked node ${id}`);
@@ -189,7 +205,7 @@ export default class Sandbox extends React.Component {
         const graphProps = {
             id: 'graph',
             data: this.state.data,
-            config: this.state.config,
+            config: Object.assign(this.state.config, {staticGraph: true}),
             onClickNode: this.onClickNode,
             onClickLink: this.onClickLink,
             onMouseOverNode: this.onMouseOverNode,

--- a/src/components/Graph/config.js
+++ b/src/components/Graph/config.js
@@ -39,8 +39,9 @@
  * @param {boolean} [panAndZoom=false] - 🚅🚅🚅 pan and zoom effect when performing zoom in the graph,
  * a similar functionality may be consulted {@link https://bl.ocks.org/mbostock/2a39a768b1d4bc00a09650edef75ad39|here}.
  * @param {boolean} [staticGraph=false] - when setting this value to true the graph will be completely static, thus
- * all forces and drag events upon nodes will produce not effect. **Plus**, if this value is true the nodes will be
- * rendered with the initial provided **x and y coordinates**, no coordinates will be calculated by react-d3-graph.
+ * all forces and drag events upon nodes will produce not effect. Note that, if this value is true the nodes will be
+ * rendered with the initial provided **x and y coordinates** (links positions will be automatically set
+ * from the given nodes positions by rd3g), no coordinates will be calculated by rd3g or subjacent d3 modules.
  * @param {number} [width=800] - the width of the (svg) area where the graph will be rendered.
  * <br/>
  * @param {Object} node node object is explained in next section.

--- a/src/components/Graph/config.js
+++ b/src/components/Graph/config.js
@@ -39,8 +39,8 @@
  * @param {boolean} [panAndZoom=false] - 🚅🚅🚅 pan and zoom effect when performing zoom in the graph,
  * a similar functionality may be consulted {@link https://bl.ocks.org/mbostock/2a39a768b1d4bc00a09650edef75ad39|here}.
  * @param {boolean} [staticGraph=false] - when setting this value to true the graph will be completely static, thus
- * all forces and drag events upon nodes will be disabled. **Plus**, if this value is true the nodes will be rendered
- * in the provided **x and y coordinates**, no coordinates will be calculated by react-d3-graph.
+ * all forces and drag events upon nodes will produce not effect. **Plus**, if this value is true the nodes will be
+ * rendered with the initial provided **x and y coordinates**, no coordinates will be calculated by react-d3-graph.
  * @param {number} [width=800] - the width of the (svg) area where the graph will be rendered.
  * <br/>
  * @param {Object} node node object is explained in next section.

--- a/src/components/Graph/helper.jsx
+++ b/src/components/Graph/helper.jsx
@@ -31,6 +31,7 @@ import Node from '../Node/';
  * @memberof Graph/helper
  */
 function _buildLinkProps(source, target, nodes, links, config, linkCallbacks, someNodeHighlighted, transform) {
+    // FIXME: Default is of string type number should be considered
     const x1 = nodes[source] && nodes[source].x || '0';
     const y1 = nodes[source] && nodes[source].y || '0';
     const x2 = nodes[target] && nodes[target].x || '0';
@@ -98,6 +99,8 @@ function _buildNodeLinks(nodeId, nodes, links, config, linkCallbacks, someNodeHi
 
             if (nodes[target]) {
                 const key = `${nodeId}${CONST.COORDS_SEPARATOR}${target}`;
+                // FIXME: Instead of assignment and desctruturing inside .push the props should directly get
+                // the results from the call to _buildLinkProps
                 const props = _buildLinkProps(
                     source,
                     target,

--- a/src/components/Graph/helper.jsx
+++ b/src/components/Graph/helper.jsx
@@ -307,8 +307,8 @@ function initializeNodes(graphNodes) {
 
         node['highlighted'] = false;
 
-        if (!n.hasOwnProperty('x')) { node['x'] = 0; }
-        if (!n.hasOwnProperty('y')) { node['y'] = 0; }
+        if (!node.hasOwnProperty('x')) { node['x'] = 0; }
+        if (!node.hasOwnProperty('y')) { node['y'] = 0; }
 
         nodes[node.id.toString()] = node;
         nodeIndexMapping[i] = node.id;

--- a/src/components/Graph/helper.jsx
+++ b/src/components/Graph/helper.jsx
@@ -31,11 +31,10 @@ import Node from '../Node/';
  * @memberof Graph/helper
  */
 function _buildLinkProps(source, target, nodes, links, config, linkCallbacks, someNodeHighlighted, transform) {
-    // FIXME: Default is of string type number should be considered
-    const x1 = nodes[source] && nodes[source].x || '0';
-    const y1 = nodes[source] && nodes[source].y || '0';
-    const x2 = nodes[target] && nodes[target].x || '0';
-    const y2 = nodes[target] && nodes[target].y || '0';
+    const x1 = nodes[source] && nodes[source].x || 0;
+    const y1 = nodes[source] && nodes[source].y || 0;
+    const x2 = nodes[target] && nodes[target].x || 0;
+    const y2 = nodes[target] && nodes[target].y || 0;
 
     let opacity = config.link.opacity;
 
@@ -99,8 +98,6 @@ function _buildNodeLinks(nodeId, nodes, links, config, linkCallbacks, someNodeHi
 
             if (nodes[target]) {
                 const key = `${nodeId}${CONST.COORDS_SEPARATOR}${target}`;
-                // FIXME: Instead of assignment and desctruturing inside .push the props should directly get
-                // the results from the call to _buildLinkProps
                 const props = _buildLinkProps(
                     source,
                     target,

--- a/test/Graph.test.js
+++ b/test/Graph.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 
 import Graph from '../src/components/Graph';
-import graphMock from './graph.mock.js'
+import graphMock from './graph.mock.js';
 
 describe('Graph Component', () => {
     let that = {};

--- a/test/__snapshots__/Graph.test.js.snap
+++ b/test/__snapshots__/Graph.test.js.snap
@@ -25,10 +25,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="40"
+        x2="140"
+        y1="200"
+        y2="20"
       />
       <line
         className="link"
@@ -40,10 +40,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="40"
+        x2="20"
+        y1="200"
+        y2="110"
       />
       <line
         className="link"
@@ -55,10 +55,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="40"
+        x2="101"
+        y1="200"
+        y2="201"
       />
       <line
         className="link"
@@ -70,10 +70,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="40"
+        x2="2"
+        y1="200"
+        y2="200"
       />
       <line
         className="link"
@@ -85,10 +85,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="40"
+        x2="14"
+        y1="200"
+        y2="250"
       />
       <line
         className="link"
@@ -100,10 +100,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="40"
+        x2="200"
+        y1="200"
+        y2="300"
       />
       <line
         className="link"
@@ -115,10 +115,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="140"
+        x2="40"
+        y1="20"
+        y2="200"
       />
       <line
         className="link"
@@ -130,10 +130,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="20"
+        x2="40"
+        y1="110"
+        y2="200"
       />
       <line
         className="link"
@@ -145,10 +145,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="20"
+        x2="305"
+        y1="110"
+        y2="745"
       />
       <line
         className="link"
@@ -160,10 +160,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="30"
+        x2="305"
+        y1="184"
+        y2="745"
       />
       <line
         className="link"
@@ -175,10 +175,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="30"
+        x2="190"
+        y1="184"
+        y2="609"
       />
       <line
         className="link"
@@ -190,10 +190,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="305"
+        x2="30"
+        y1="745"
+        y2="184"
       />
       <line
         className="link"
@@ -205,10 +205,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="305"
+        x2="200"
+        y1="745"
+        y2="300"
       />
       <line
         className="link"
@@ -220,10 +220,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="305"
+        x2="120"
+        y1="745"
+        y2="270"
       />
       <line
         className="link"
@@ -235,10 +235,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="305"
+        x2="20"
+        y1="745"
+        y2="110"
       />
       <line
         className="link"
@@ -250,10 +250,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="305"
+        x2="190"
+        y1="745"
+        y2="609"
       />
       <line
         className="link"
@@ -265,10 +265,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="200"
+        x2="305"
+        y1="300"
+        y2="745"
       />
       <line
         className="link"
@@ -280,10 +280,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="200"
+        x2="40"
+        y1="300"
+        y2="200"
       />
       <line
         className="link"
@@ -295,10 +295,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="120"
+        x2="305"
+        y1="270"
+        y2="745"
       />
       <line
         className="link"
@@ -310,10 +310,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="120"
+        x2="14"
+        y1="270"
+        y2="20"
       />
       <line
         className="link"
@@ -325,10 +325,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="190"
+        x2="305"
+        y1="609"
+        y2="745"
       />
       <line
         className="link"
@@ -340,10 +340,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="190"
+        x2="30"
+        y1="609"
+        y2="184"
       />
       <line
         className="link"
@@ -355,10 +355,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="190"
+        x2="14"
+        y1="609"
+        y2="259"
       />
       <line
         className="link"
@@ -370,10 +370,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="190"
+        x2="409"
+        y1="609"
+        y2="500"
       />
       <line
         className="link"
@@ -385,10 +385,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="101"
+        x2="40"
+        y1="201"
+        y2="200"
       />
       <line
         className="link"
@@ -400,10 +400,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="2"
+        x2="40"
+        y1="200"
+        y2="200"
       />
       <line
         className="link"
@@ -415,10 +415,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="404"
+        x2="14"
+        y1="404"
+        y2="30"
       />
       <line
         className="link"
@@ -430,10 +430,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="14"
+        x2="404"
+        y1="30"
+        y2="404"
       />
       <line
         className="link"
@@ -445,10 +445,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="14"
+        x2="40"
+        y1="250"
+        y2="200"
       />
       <line
         className="link"
@@ -460,10 +460,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="14"
+        x2="190"
+        y1="259"
+        y2="609"
       />
       <line
         className="link"
@@ -475,10 +475,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="14"
+        x2="520"
+        y1="259"
+        y2="123"
       />
       <line
         className="link"
@@ -490,10 +490,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="409"
+        x2="190"
+        y1="500"
+        y2="609"
       />
       <line
         className="link"
@@ -505,10 +505,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="520"
+        x2="14"
+        y1="123"
+        y2="259"
       />
       <line
         className="link"
@@ -520,10 +520,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="14"
+        x2="120"
+        y1="20"
+        y2="270"
       />
       <line
         className="link"
@@ -535,10 +535,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="20"
+        x2="90"
+        y1="1"
+        y2="90"
       />
       <line
         className="link"
@@ -550,10 +550,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="90"
+        x2="20"
+        y1="90"
+        y2="1"
       />
       <line
         className="link"
@@ -565,10 +565,10 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="90"
+        x2="90"
+        y1="90"
+        y2="656"
       />
       <line
         className="link"
@@ -580,17 +580,17 @@ exports[`Graph Component should be properly rendered 1`] = `
             "strokeWidth": 1.5,
           }
         }
-        x1="0"
-        x2="0"
-        y1="0"
-        y2="0"
+        x1="90"
+        x2="90"
+        y1="656"
+        y2="90"
       />
       <g
         className="node"
-        cx="0"
-        cy="0"
+        cx="40"
+        cy="200"
         id="Harry"
-        transform="translate(0,0)"
+        transform="translate(40,200)"
       >
         <path
           cursor="pointer"
@@ -615,10 +615,10 @@ exports[`Graph Component should be properly rendered 1`] = `
       </g>
       <g
         className="node"
-        cx="0"
-        cy="0"
+        cx="140"
+        cy="20"
         id="Sally"
-        transform="translate(0,0)"
+        transform="translate(140,20)"
       >
         <path
           cursor="pointer"
@@ -643,10 +643,10 @@ exports[`Graph Component should be properly rendered 1`] = `
       </g>
       <g
         className="node"
-        cx="0"
-        cy="0"
+        cx="20"
+        cy="110"
         id="Mario"
-        transform="translate(0,0)"
+        transform="translate(20,110)"
       >
         <path
           cursor="pointer"
@@ -671,10 +671,10 @@ exports[`Graph Component should be properly rendered 1`] = `
       </g>
       <g
         className="node"
-        cx="0"
-        cy="0"
+        cx="30"
+        cy="184"
         id="Sarah"
-        transform="translate(0,0)"
+        transform="translate(30,184)"
       >
         <path
           cursor="pointer"
@@ -699,10 +699,10 @@ exports[`Graph Component should be properly rendered 1`] = `
       </g>
       <g
         className="node"
-        cx="0"
-        cy="0"
+        cx="305"
+        cy="745"
         id="Alice"
-        transform="translate(0,0)"
+        transform="translate(305,745)"
       >
         <path
           cursor="pointer"
@@ -727,10 +727,10 @@ exports[`Graph Component should be properly rendered 1`] = `
       </g>
       <g
         className="node"
-        cx="0"
-        cy="0"
+        cx="200"
+        cy="300"
         id="Eveie"
-        transform="translate(0,0)"
+        transform="translate(200,300)"
       >
         <path
           cursor="pointer"
@@ -755,10 +755,10 @@ exports[`Graph Component should be properly rendered 1`] = `
       </g>
       <g
         className="node"
-        cx="0"
-        cy="0"
+        cx="120"
+        cy="270"
         id="Peter"
-        transform="translate(0,0)"
+        transform="translate(120,270)"
       >
         <path
           cursor="pointer"
@@ -783,10 +783,10 @@ exports[`Graph Component should be properly rendered 1`] = `
       </g>
       <g
         className="node"
-        cx="0"
-        cy="0"
+        cx="190"
+        cy="609"
         id="James"
-        transform="translate(0,0)"
+        transform="translate(190,609)"
       >
         <path
           cursor="pointer"
@@ -811,10 +811,10 @@ exports[`Graph Component should be properly rendered 1`] = `
       </g>
       <g
         className="node"
-        cx="0"
-        cy="0"
+        cx="101"
+        cy="201"
         id="Carol"
-        transform="translate(0,0)"
+        transform="translate(101,201)"
       >
         <path
           cursor="pointer"
@@ -839,10 +839,10 @@ exports[`Graph Component should be properly rendered 1`] = `
       </g>
       <g
         className="node"
-        cx="0"
-        cy="0"
+        cx="2"
+        cy="200"
         id="Nicky"
-        transform="translate(0,0)"
+        transform="translate(2,200)"
       >
         <path
           cursor="pointer"
@@ -867,10 +867,10 @@ exports[`Graph Component should be properly rendered 1`] = `
       </g>
       <g
         className="node"
-        cx="0"
-        cy="0"
+        cx="404"
+        cy="404"
         id="Bobby"
-        transform="translate(0,0)"
+        transform="translate(404,404)"
       >
         <path
           cursor="pointer"
@@ -895,10 +895,10 @@ exports[`Graph Component should be properly rendered 1`] = `
       </g>
       <g
         className="node"
-        cx="0"
-        cy="0"
+        cx="14"
+        cy="30"
         id="Frank"
-        transform="translate(0,0)"
+        transform="translate(14,30)"
       >
         <path
           cursor="pointer"
@@ -923,10 +923,10 @@ exports[`Graph Component should be properly rendered 1`] = `
       </g>
       <g
         className="node"
-        cx="0"
-        cy="0"
+        cx="14"
+        cy="250"
         id="Lynne"
-        transform="translate(0,0)"
+        transform="translate(14,250)"
       >
         <path
           cursor="pointer"
@@ -951,10 +951,10 @@ exports[`Graph Component should be properly rendered 1`] = `
       </g>
       <g
         className="node"
-        cx="0"
-        cy="0"
+        cx="14"
+        cy="259"
         id="Roger"
-        transform="translate(0,0)"
+        transform="translate(14,259)"
       >
         <path
           cursor="pointer"
@@ -979,10 +979,10 @@ exports[`Graph Component should be properly rendered 1`] = `
       </g>
       <g
         className="node"
-        cx="0"
-        cy="0"
+        cx="409"
+        cy="500"
         id="Maddy"
-        transform="translate(0,0)"
+        transform="translate(409,500)"
       >
         <path
           cursor="pointer"
@@ -1007,10 +1007,10 @@ exports[`Graph Component should be properly rendered 1`] = `
       </g>
       <g
         className="node"
-        cx="0"
-        cy="0"
+        cx="520"
+        cy="123"
         id="Sonny"
-        transform="translate(0,0)"
+        transform="translate(520,123)"
       >
         <path
           cursor="pointer"
@@ -1035,10 +1035,10 @@ exports[`Graph Component should be properly rendered 1`] = `
       </g>
       <g
         className="node"
-        cx="0"
-        cy="0"
+        cx="14"
+        cy="20"
         id="Johan"
-        transform="translate(0,0)"
+        transform="translate(14,20)"
       >
         <path
           cursor="pointer"
@@ -1063,10 +1063,10 @@ exports[`Graph Component should be properly rendered 1`] = `
       </g>
       <g
         className="node"
-        cx="0"
-        cy="0"
+        cx="20"
+        cy="1"
         id="Henry"
-        transform="translate(0,0)"
+        transform="translate(20,1)"
       >
         <path
           cursor="pointer"
@@ -1091,10 +1091,10 @@ exports[`Graph Component should be properly rendered 1`] = `
       </g>
       <g
         className="node"
-        cx="0"
-        cy="0"
+        cx="90"
+        cy="90"
         id="Mikey"
-        transform="translate(0,0)"
+        transform="translate(90,90)"
       >
         <path
           cursor="pointer"
@@ -1119,10 +1119,10 @@ exports[`Graph Component should be properly rendered 1`] = `
       </g>
       <g
         className="node"
-        cx="0"
-        cy="0"
+        cx="90"
+        cy="656"
         id="Elric"
-        transform="translate(0,0)"
+        transform="translate(90,656)"
       >
         <path
           cursor="pointer"


### PR DESCRIPTION
This PR fixes https://github.com/danielcaldas/react-d3-graph/issues/24, additionally it adds to the `Sandbox` component an example (with random generated values) on how to properly set positions for nodes x and y props:

```javascript
decorateGraphNodesWithInitialPositioning = (nodes) => {
        return nodes.map(n => ({
            id: n.id,
            x: Math.floor(Math.random() * 500),
            y: Math.floor(Math.random() * 500),
            symbolType: n.symbolType || 'circle'
        }));
}
```

Also
- Add .editorconfig
- Config lint rules for test files with `eslint-plugin-jest`