### PR TITLE
Feature/on mouse over and out link

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,7 +25,7 @@ module.exports = {
         "camelcase": "error",
         "keyword-spacing": "error",
         "max-len": ["error", 120, 4, { "ignoreComments": true }],
-        "max-lines": ["error", {"max": 300, "skipComments": true}],
+        "max-lines": ["error", {"max": 400, "skipComments": true}],
         "newline-after-var": ["error", "always"],
         "no-nested-ternary": "error",
         "no-useless-constructor": "error",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# react-d3-graph &middot; [![Build Status](https://travis-ci.org/danielcaldas/react-d3-graph.svg?branch=master)](https://travis-ci.org/danielcaldas/react-d3-graph) [![npm version](https://img.shields.io/badge/npm-v0.4.0-blue.svg)](https://www.npmjs.com/package/react-d3-graph) [![npm stats](https://img.shields.io/badge/downloads-900+-brightgreen.svg)](https://npm-stat.com/) [![probot enabled](https://img.shields.io/badge/probot:stale-enabled-yellow.svg)](https://probot.github.io/)
+# react-d3-graph &middot; [![Build Status](https://travis-ci.org/danielcaldas/react-d3-graph.svg?branch=master)](https://travis-ci.org/danielcaldas/react-d3-graph) [![npm version](https://img.shields.io/badge/npm-v0.4.0-blue.svg)](https://www.npmjs.com/package/react-d3-graph) [![npm stats](https://img.shields.io/badge/downloads-1k+-brightgreen.svg)](https://npm-stat.com/charts.html?package=react-d3-graph&from=2017-04-25&to=2017-11-24) [![probot enabled](https://img.shields.io/badge/probot:stale-enabled-yellow.svg)](https://probot.github.io/)
 [:book:](https://danielcaldas.github.io/react-d3-graph/docs/index.html)
 
 ### *Interactive and configurable graphs with react and d3 effortlessly*

--- a/sandbox/Sandbox.jsx
+++ b/sandbox/Sandbox.jsx
@@ -73,7 +73,7 @@ export default class Sandbox extends React.Component {
     pauseGraphSimulation = () => this.refs.graph.pauseSimulation();
 
     /**
-     * If you have moved nodes you will have them restore theire positions
+     * If you have moved nodes you will have them restore theirs positions
      * when you call resetNodesPositions.
      */
     resetNodesPositions = () => this.refs.graph.resetNodesPositions();

--- a/sandbox/Sandbox.jsx
+++ b/sandbox/Sandbox.jsx
@@ -49,6 +49,10 @@ export default class Sandbox extends React.Component {
 
     onMouseOutNode = (id) => console.info(`Do something when mouse is out of node (${id})`);
 
+    onMouseOverLink = (source, target) => console.info(`Do something when mouse is over link between ${source} and ${target}`);
+
+    onMouseOutLink = (source, target) => console.info(`Do something when mouse is out of link between ${source} and ${target}`);
+
     /**
      * Sets on/off fullscreen visualization mode.
      */
@@ -248,7 +252,9 @@ export default class Sandbox extends React.Component {
             onClickNode: this.onClickNode,
             onClickLink: this.onClickLink,
             onMouseOverNode: this.onMouseOverNode,
-            onMouseOutNode: this.onMouseOutNode
+            onMouseOutNode: this.onMouseOutNode,
+            onMouseOverLink: this.onMouseOverLink,
+            onMouseOutLink: this.onMouseOutLink
         };
 
         if (this.state.fullscreen) {

--- a/src/components/graph/config.js
+++ b/src/components/graph/config.js
@@ -30,14 +30,16 @@
  * @param {boolean} [automaticRearrangeAfterDropNode=false] - 🚅🚅🚅 when true performing a node drag and drop should automatically
  * rearrange all nodes positions based on new position of dragged node (note: **staticGraph** should be false).
  * @param {number} [height=400] - the height of the (svg) area where the graph will be rendered.
- * @param {boolean} [highlightBehavior=false] - 🚅🚅🚅 when user mouse hovers a node that node and adjacent common
- * connections will be highlighted. All the remaining nodes and links assume opacity value equal to **highlightOpacity**.
+ * @param {boolean} [nodeHighlightBehavior=false] - 🚅🚅🚅 when user mouse hovers a node that node and adjacent common
+ * connections will be highlighted (depending on the *highlightDegree* value). All the remaining nodes and links assume opacity value equal to **highlightOpacity**.
+ * @param {boolean} [linkHighlightBehavior] - 🚅🚅🚅 when the user mouse hovers some link that link and the correspondent nodes will be highlighted, this is a similar behavior
+ * to *nodeHighlightBehavior* but for links (just for historical reference this property was introduced in *v1.0.0*).
  * @param {number} [highlightDegree=1] - **Possible values: 0, 1 or 2**. This value represents the range of the
  * highlight behavior when some node is highlighted. If the value is set to **0** only the selected node will be
  * highlighted. If the value is set to **1** the selected node and his 1st degree connections will be highlighted. If
  * the value is set to **2** the selected node will be highlighted as well as the 1st and 2nd common degree connections.
  * @param {number} [highlightOpacity=1] - this value is used to highlight nodes in the network. The lower
- * the value the more the less highlighted nodes will be visible (related to *highlightBehavior*).
+ * the value the more the less highlighted nodes will be visible (related to *nodeHighlightBehavior*).
  * @param {number} [maxZoom=8] - max zoom that can be performed against the graph.
  * @param {number} [minZoom=0.1] - min zoom that can be performed against the graph.
  * @param {boolean} [panAndZoom=false] - 🚅🚅🚅 pan and zoom effect when performing zoom in the graph,
@@ -102,7 +104,7 @@
  * @example
  * // A simple config that uses some properties
  * const myConfig = {
- *     highlightBehavior: true,
+ *     nodeHighlightBehavior: true,
  *     node: {
  *         color: 'lightgreen',
  *         size: 120,
@@ -118,11 +120,12 @@
 export default {
     automaticRearrangeAfterDropNode: false,
     height: 400,
-    highlightBehavior: false,
     highlightDegree: 1,
     highlightOpacity: 1,
+    linkHighlightBehavior: false,
     maxZoom: 8,
     minZoom: 0.1,
+    nodeHighlightBehavior: false,
     panAndZoom: false,
     staticGraph: false,
     width: 800,

--- a/src/components/graph/config.js
+++ b/src/components/graph/config.js
@@ -33,7 +33,7 @@
  * @param {boolean} [nodeHighlightBehavior=false] - 🚅🚅🚅 when user mouse hovers a node that node and adjacent common
  * connections will be highlighted (depending on the *highlightDegree* value). All the remaining nodes and links assume opacity value equal to **highlightOpacity**.
  * @param {boolean} [linkHighlightBehavior=false] - 🚅🚅🚅 when the user mouse hovers some link that link and the correspondent nodes will be highlighted, this is a similar behavior
- * to *nodeHighlightBehavior* but for links (just for historical reference this property was introduced in *v1.0.0*).
+ * to *nodeHighlightBehavior* but for links <small>(just for historical reference this property was introduced in **v1.0.0**)</small>.
  * @param {number} [highlightDegree=1] - **Possible values: 0, 1 or 2**. This value represents the range of the
  * highlight behavior when some node is highlighted. If the value is set to **0** only the selected node will be
  * highlighted. If the value is set to **1** the selected node and his 1st degree connections will be highlighted. If

--- a/src/components/graph/config.js
+++ b/src/components/graph/config.js
@@ -32,7 +32,7 @@
  * @param {number} [height=400] - the height of the (svg) area where the graph will be rendered.
  * @param {boolean} [nodeHighlightBehavior=false] - 🚅🚅🚅 when user mouse hovers a node that node and adjacent common
  * connections will be highlighted (depending on the *highlightDegree* value). All the remaining nodes and links assume opacity value equal to **highlightOpacity**.
- * @param {boolean} [linkHighlightBehavior] - 🚅🚅🚅 when the user mouse hovers some link that link and the correspondent nodes will be highlighted, this is a similar behavior
+ * @param {boolean} [linkHighlightBehavior=false] - 🚅🚅🚅 when the user mouse hovers some link that link and the correspondent nodes will be highlighted, this is a similar behavior
  * to *nodeHighlightBehavior* but for links (just for historical reference this property was introduced in *v1.0.0*).
  * @param {number} [highlightDegree=1] - **Possible values: 0, 1 or 2**. This value represents the range of the
  * highlight behavior when some node is highlighted. If the value is set to **0** only the selected node will be

--- a/src/components/graph/config.js
+++ b/src/components/graph/config.js
@@ -98,7 +98,11 @@
  * ```javascript
  * strokeWidth += (linkValue * strokeWidth) / 10;
  * ```
- * @param {number} [link.strokeWidth=1.5] - strokeWidth for all links.
+ * @param {number} [link.strokeWidth=1.5] - strokeWidth for all links. By default the actual value is obtain by the
+ * following expression:
+ * ```javascript
+ * link.strokeWidth * (1 / transform); // transform is a zoom delta Δ value
+ * ```
  * @param {string} [link.highlightColor='#d3d3d3'] - links' color in highlight state.
  *
  * @example

--- a/src/components/graph/helper.jsx
+++ b/src/components/graph/helper.jsx
@@ -147,7 +147,7 @@ function _buildNodeLinks(nodeId, nodes, links, config, linkCallbacks, highlighte
 }
 
 /**
- * Get the correct node opacity in order to properly make decisions based on context such as currently highlited node.
+ * Get the correct node opacity in order to properly make decisions based on context such as currently highlighted node.
  * @param  {Object} node - the node object for whom we will generate properties.
  * @param  {string} highlightedNode - same as {@link #buildGraph|highlightedNode in buildGraph}.
  * @param  {Object} config - same as {@link #buildGraph|config in buildGraph}.
@@ -253,10 +253,10 @@ function _buildNodeProps(node, config, nodeCallbacks, highlightedNode, transform
  *  }
  * ```
  * @param  {Function[]} linkCallbacks - array of callbacks for used defined event handler for link interactions.
- * @param  {Object} config - an object containg rd3g consumer defined configurations {@link #config config} for the graph.
+ * @param  {Object} config - an object containing rd3g consumer defined configurations {@link #config config} for the graph.
  * @param  {string} highlightedNode - this value contains a string that represents the some currently highlighted node.
  * @param  {number} transform - value that indicates the amount of zoom transformation.
- * @returns {Object} returns an object containg the generated nodes and links that form the graph. The result is
+ * @returns {Object} returns an object containing the generated nodes and links that form the graph. The result is
  * returned in a way that can be consumed by es6 **destructuring assignment**.
  * @memberof Graph/helper
  */
@@ -357,7 +357,7 @@ function initializeGraphState({data, id, config}, state) {
 /**
  * Receives a matrix of the graph with the links source and target as concrete node instances and it transforms it
  * in a lightweight matrix containing only links with source and target being strings representative of some node id
- * and the respective link value (if non existant will default to 1).
+ * and the respective link value (if non existent will default to 1).
  * @param  {Object[]} graphLinks - an array of all graph links but all the links contain the source and target nodes
  * objects.
  * @returns {Object.<string, Object>} an object containing a matrix of connections of the graph, for each nodeId,
@@ -415,7 +415,7 @@ function initializeNodes(graphNodes) {
 }
 
 /**
- * Some integraty validations on links and nodes structure. If some validation fails the function will
+ * Some integrity validations on links and nodes structure. If some validation fails the function will
  * throw an error.
  * @param  {Object} data - Same as {@link #initializeGraphState|data in initializeGraphState}.
  * @memberof Graph/helper

--- a/src/components/graph/helper.jsx
+++ b/src/components/graph/helper.jsx
@@ -323,7 +323,7 @@ function createForceSimulation(width, height) {
 }
 
 /**
- * Incapsulates common procedures to initialize graph.
+ * Encapsulates common procedures to initialize graph.
  * @param {Object} props - Graph component props, object that holds data, id and config.
  * @param {Object} props.data - Data object holds links (array of **Link**) and nodes (array of **Node**).
  * @param {string} props.id - the graph id.
@@ -338,7 +338,7 @@ function initializeGraphState({data, id, config}, state) {
     validateGraphData(data);
 
     if (state && state.nodes && state.links && state.nodeIndexMapping) {
-        // absorve existent positining
+        // absorb existent positioning
         graph = {
             nodes: data.nodes.map(n => Object.assign({}, n, state.nodes[n.id])),
             links: {}

--- a/src/components/graph/helper.jsx
+++ b/src/components/graph/helper.jsx
@@ -51,24 +51,25 @@ function _buildLinkProps(source, target, nodes, links, config, linkCallbacks, hi
     const x2 = nodes[target] && nodes[target].x || 0;
     const y2 = nodes[target] && nodes[target].y || 0;
 
-    let opacity = config.link.opacity;
-    let mainNodeParticipates;
+    let mainNodeParticipates = false;
 
     switch (config.highlightDegree) {
         case 0:
-            break;
+        break;
         case 2:
-            mainNodeParticipates = true;
-            break;
+        mainNodeParticipates = true;
+        break;
         default: // 1st degree is the fallback behavior
-            mainNodeParticipates = source === highlightedNode || target === highlightedNode;
-            break;
+        mainNodeParticipates = source === highlightedNode || target === highlightedNode;
+        break;
     }
 
-    const highlight = (mainNodeParticipates && nodes[source].highlighted && nodes[target].highlighted) 
-                        || (source === (highlightedLink && highlightedLink.source) && target === (highlightedLink && highlightedLink.target));
+    const highlight = (mainNodeParticipates && nodes[source].highlighted && nodes[target].highlighted)
+                    || (source === (highlightedLink && highlightedLink.source) && target === (highlightedLink && highlightedLink.target));
 
-    if (highlightedNode || highlightedLink && highlightedLink.source) {
+    let opacity = config.link.opacity;
+
+    if (highlightedNode || (highlightedLink && highlightedLink.source)) {
         opacity = highlight ? config.link.opacity : config.highlightOpacity;
     }
 
@@ -79,11 +80,11 @@ function _buildLinkProps(source, target, nodes, links, config, linkCallbacks, hi
                                                                     : config.link.highlightColor;
     }
 
-    const linkValue = links[source][target] || links[target][source] || 1;
-
     let strokeWidth = config.link.strokeWidth * (1 / transform);
 
     if (config.link.semanticStrokeWidth) {
+        const linkValue = links[source][target] || links[target][source] || 1;
+
         strokeWidth += (linkValue * strokeWidth) / 10;
     }
 

--- a/src/components/graph/helper.jsx
+++ b/src/components/graph/helper.jsx
@@ -84,7 +84,7 @@ function _buildLinkProps(source, target, nodes, links, config, linkCallbacks, hi
     if (config.link.semanticStrokeWidth) {
         strokeWidth += (linkValue * strokeWidth) / 10;
     }
-
+    
     return {
         source,
         target,
@@ -96,7 +96,9 @@ function _buildLinkProps(source, target, nodes, links, config, linkCallbacks, hi
         stroke,
         className: CONST.LINK_CLASS_NAME,
         opacity,
-        onClickLink: linkCallbacks.onClickLink
+        onClickLink: linkCallbacks.onClickLink,
+        onMouseOverLink: linkCallbacks.onMouseOverLink,
+        onMouseOutLink: linkCallbacks.onMouseOutLink
     };
 }
 
@@ -261,7 +263,7 @@ function _buildNodeProps(node, config, nodeCallbacks, highlightedNode, transform
 function buildGraph(nodes, nodeCallbacks, links, linkCallbacks, config, highlightedNode, transform) {
     let linksComponents = [];
     let nodesComponents = [];
-
+    
     for (let i = 0, keys = Object.keys(nodes), n = keys.length; i < n; i++) {
         const nodeId = keys[i];
 

--- a/src/components/graph/helper.jsx
+++ b/src/components/graph/helper.jsx
@@ -329,7 +329,7 @@ function createForceSimulation(width, height) {
  * @param {string} props.id - the graph id.
  * @param {Object} props.config - same as {@link #buildGraph|config in buildGraph}.
  * @param {Object} state - Graph component current state (same format as returned object on this function).
- * @returns a fully (re)initialized graph state object.
+ * @returns {Object} a fully (re)initialized graph state object.
  * @memberof Graph/helper
  */
 function initializeGraphState({data, id, config}, state) {

--- a/src/components/graph/helper.jsx
+++ b/src/components/graph/helper.jsx
@@ -45,7 +45,8 @@ import utils from '../../utils';
  * @returns {Object} returns an object that aggregates all props for creating respective Link component instance.
  * @memberof Graph/helper
  */
-function _buildLinkProps(source, target, nodes, links, config, linkCallbacks, highlightedNode, highlightedLink, transform) {
+function _buildLinkProps(source, target, nodes, links, config, linkCallbacks, highlightedNode,
+     highlightedLink, transform) {
     const x1 = nodes[source] && nodes[source].x || 0;
     const y1 = nodes[source] && nodes[source].y || 0;
     const x2 = nodes[target] && nodes[target].x || 0;
@@ -64,8 +65,10 @@ function _buildLinkProps(source, target, nodes, links, config, linkCallbacks, hi
         break;
     }
 
-    const highlight = (mainNodeParticipates && nodes[source].highlighted && nodes[target].highlighted)
-                    || (source === (highlightedLink && highlightedLink.source) && target === (highlightedLink && highlightedLink.target));
+    const reasonNode = mainNodeParticipates && nodes[source].highlighted && nodes[target].highlighted;
+    const reasonLink = source === (highlightedLink && highlightedLink.source) 
+                    && target === (highlightedLink && highlightedLink.target);
+    const highlight = reasonNode || reasonLink;
 
     let opacity = config.link.opacity;
 
@@ -161,8 +164,11 @@ function _buildNodeLinks(nodeId, nodes, links, config, linkCallbacks, highlighte
  * @memberof Graph/helper
  */
 function _getNodeOpacity(node, highlightedNode, highlightedLink, config) {
-    const highlight = node.highlighted || node.id === (highlightedLink && highlightedLink.source) || node.id === (highlightedLink && highlightedLink.target);
-    const someNodeHighlighted = !!(highlightedNode || highlightedLink && highlightedLink.source && highlightedLink.target);
+    const highlight = node.highlighted
+                 || node.id === (highlightedLink && highlightedLink.source)
+                 || node.id === (highlightedLink && highlightedLink.target);
+    const someNodeHighlighted = !!(highlightedNode
+                        || highlightedLink && highlightedLink.source && highlightedLink.target);
     let opacity;
 
     if (someNodeHighlighted && config.highlightDegree === 0) {
@@ -188,7 +194,9 @@ function _getNodeOpacity(node, highlightedNode, highlightedLink, config) {
  * @memberof Graph/helper
  */
 function _buildNodeProps(node, config, nodeCallbacks, highlightedNode, highlightedLink, transform) {
-    const highlight = node.highlighted || (node.id === (highlightedLink && highlightedLink.source) || node.id === (highlightedLink && highlightedLink.target));
+    const highlight = node.highlighted 
+                    || (node.id === (highlightedLink && highlightedLink.source)
+                    || node.id === (highlightedLink && highlightedLink.target));
     const opacity = _getNodeOpacity(node, highlightedNode, highlightedLink, config);
     let fill = node.color || config.node.color;
 
@@ -279,7 +287,8 @@ function buildGraph(nodes, nodeCallbacks, links, linkCallbacks, config, highligh
     for (let i = 0, keys = Object.keys(nodes), n = keys.length; i < n; i++) {
         const nodeId = keys[i];
 
-        const props = _buildNodeProps(nodes[nodeId], config, nodeCallbacks, highlightedNode, highlightedLink, transform);
+        const props = _buildNodeProps(nodes[nodeId], config, nodeCallbacks,
+                                        highlightedNode, highlightedLink, transform);
 
         nodesComponents.push(<Node key={nodeId} {...props} />);
 

--- a/src/components/graph/helper.jsx
+++ b/src/components/graph/helper.jsx
@@ -65,15 +65,16 @@ function _buildLinkProps(source, target, nodes, links, config, linkCallbacks, hi
             break;
     }
 
-    if (highlightedNode) {
-        opacity = (mainNodeParticipates
-                && nodes[source].highlighted
-                && nodes[target].highlighted) ? config.link.opacity : config.highlightOpacity;
+    const highlight = (mainNodeParticipates && nodes[source].highlighted && nodes[target].highlighted) 
+                        || (source === (highlightedLink && highlightedLink.source) && target === (highlightedLink && highlightedLink.target));
+
+    if (highlightedNode || highlightedLink && highlightedLink.source) {
+        opacity = highlight ? config.link.opacity : config.highlightOpacity;
     }
 
     let stroke = config.link.color;
 
-    if (mainNodeParticipates && nodes[source].highlighted && nodes[target].highlighted) {
+    if (highlight) {
         stroke = config.link.highlightColor === CONST.KEYWORDS.SAME ? config.link.color
                                                                     : config.link.highlightColor;
     }

--- a/src/components/graph/helper.jsx
+++ b/src/components/graph/helper.jsx
@@ -66,7 +66,7 @@ function _buildLinkProps(source, target, nodes, links, config, linkCallbacks, hi
     }
 
     const reasonNode = mainNodeParticipates && nodes[source].highlighted && nodes[target].highlighted;
-    const reasonLink = source === (highlightedLink && highlightedLink.source) 
+    const reasonLink = source === (highlightedLink && highlightedLink.source)
                     && target === (highlightedLink && highlightedLink.target);
     const highlight = reasonNode || reasonLink;
 
@@ -194,7 +194,7 @@ function _getNodeOpacity(node, highlightedNode, highlightedLink, config) {
  * @memberof Graph/helper
  */
 function _buildNodeProps(node, config, nodeCallbacks, highlightedNode, highlightedLink, transform) {
-    const highlight = node.highlighted 
+    const highlight = node.highlighted
                     || (node.id === (highlightedLink && highlightedLink.source)
                     || node.id === (highlightedLink && highlightedLink.target));
     const opacity = _getNodeOpacity(node, highlightedNode, highlightedLink, config);
@@ -440,16 +440,27 @@ function initializeNodes(graphNodes) {
  * throw an error.
  * @param  {Object} data - Same as {@link #initializeGraphState|data in initializeGraphState}.
  * @memberof Graph/helper
+ * @throws can throw the following error msg:
+ * INSUFFICIENT_DATA - msg if no nodes are provided
+ * INVALID_LINKS - if links point to nonexistent nodes
  */
 function validateGraphData(data) {
-    data.links.forEach(l => {
+    if (!data.nodes || !data.nodes.length) {
+        utils.throwErr('Graph', ERRORS.INSUFFICIENT_DATA);
+    }
+
+    const n = data.links.length;
+
+    for (let i=0; i < n; i++) {
+        const l = data.links[i];
+
         if (!data.nodes.find(n => n.id === l.source)) {
-            utils.throwErr(this.constructor.name, `${ERRORS.INVALID_LINKS} - ${l.source} is not a valid node id`);
+            utils.throwErr('Graph', `${ERRORS.INVALID_LINKS} - ${l.source} is not a valid node id`);
         }
         if (!data.nodes.find(n => n.id === l.target)) {
-            utils.throwErr(this.constructor.name, `${ERRORS.INVALID_LINKS} - ${l.target} is not a valid node id`);
+            utils.throwErr('Graph', `${ERRORS.INVALID_LINKS} - ${l.target} is not a valid node id`);
         }
-    });
+    }
 }
 
 export default {

--- a/src/components/graph/index.jsx
+++ b/src/components/graph/index.jsx
@@ -44,7 +44,8 @@ const D3_CONST = {
  *     ]
  * };
  *
- * // The graph configuration
+ * // The graph configuration, you only need to pass down properties
+ * // that you want to override, otherwise default will be used
  * const myConfig = {
  *     nodeHighlightBehavior: true,
  *     node: {
@@ -59,19 +60,27 @@ const D3_CONST = {
  *
  * // Graph event callbacks
  * const onClickNode = function(nodeId) {
- *      window.alert('Clicked node', nodeId);
+ *      window.alert('Clicked node ${nodeId}');
  * };
  *
  * const onMouseOverNode = function(nodeId) {
- *      window.alert('Mouse over node', nodeId);
+ *      window.alert(`Mouse over node ${nodeId}`);
  * };
  *
  * const onMouseOutNode = function(nodeId) {
- *      window.alert('Mouse out node', nodeId);
+ *      window.alert(`Mouse out node ${nodeId}`);
  * };
  *
  * const onClickLink = function(source, target) {
  *      window.alert(`Clicked link between ${source} and ${target}`);
+ * };
+ * 
+ * const onMouseOverLink = function(source, target) {
+ *      window.alert(`Mouse over in link between ${source} and ${target}`);
+ * };
+ *
+ * const onMouseOutLink = function(source, target) {
+ *      window.alert(`Mouse out link between ${source} and ${target}`);
  * };
  *
  * <Graph
@@ -81,7 +90,9 @@ const D3_CONST = {
  *      onClickNode={onClickNode}
  *      onClickLink={onClickLink}
  *      onMouseOverNode={onMouseOverNode}
- *      onMouseOutNode={onMouseOutNode} />
+ *      onMouseOutNode={onMouseOutNode}
+ *      onMouseOverLink={onMouseOverLink}
+ *      onMouseOutLink={onMouseOutLink}/>
  */
 export default class Graph extends React.Component {
     /**
@@ -184,7 +195,8 @@ export default class Graph extends React.Component {
 
     /**
      * Handles mouse over link event.
-     * @TODO
+     * @param  {string} source - id of the source node that participates in the event.
+     * @param  {string} target - id of the target node that participates in the event.
      */
     onMouseOverLink = (source, target) => {
         this.props.onMouseOverLink && this.props.onMouseOverLink(source, target);
@@ -198,7 +210,8 @@ export default class Graph extends React.Component {
 
     /**
      * Handles mouse out link event.
-     * @TODO
+     * @param  {string} source - id of the source node that participates in the event.
+     * @param  {string} target - id of the target node that participates in the event.
      */
     onMouseOutLink = (source, target) => {
         this.props.onMouseOutLink && this.props.onMouseOutLink(source, target);

--- a/src/components/graph/index.jsx
+++ b/src/components/graph/index.jsx
@@ -181,7 +181,7 @@ export default class Graph extends React.Component {
 
         this.state.config.highlightBehavior && this._setHighlighted(id, false);
     }
-    
+
     /**
      * Handles mouse over link event.
      * @TODO
@@ -191,8 +191,9 @@ export default class Graph extends React.Component {
 
         // this.state.config.highlightBehavior && this._setHighlighted(index, true);
         if (this.state.config.highlightBehavior) {
-            this._setHighlighted(source, true);
-            this._setHighlighted(target, true);
+            this.state.highlightedLink = { source, target };
+
+            this._tick();
         }
     }
 
@@ -205,8 +206,9 @@ export default class Graph extends React.Component {
 
         // this.state.config.highlightBehavior && this._setHighlighted(index, false);
         if (this.state.config.highlightBehavior) {
-            this._setHighlighted(source, false);
-            this._setHighlighted(target, false);
+            this.state.highlightedLink = undefined;
+
+            this._tick();
         }
     }
 
@@ -346,6 +348,7 @@ export default class Graph extends React.Component {
             },
             this.state.config,
             this.state.highlightedNode,
+            this.state.highlightedLink,
             this.state.transform
         );
 

--- a/src/components/graph/index.jsx
+++ b/src/components/graph/index.jsx
@@ -119,16 +119,16 @@ export default class Graph extends React.Component {
 
     /**
      * Sets nodes and links highlighted value.
-     * @param  {number} index - the index of the node to highlight (and its adjacent).
+     * @param  {string} id - the id of the node to highlight.
      * @param  {boolean} [value=false] - the highlight value to be set (true or false).
      */
-    _setHighlighted = (index, value=false) => {
-        this.state.highlightedNode = value ? index : '';
-        this.state.nodes[index].highlighted = value;
+    _setHighlighted = (id, value=false) => {
+        this.state.highlightedNode = value ? id : '';
+        this.state.nodes[id].highlighted = value;
 
         // when highlightDegree is 0 we want only to highlight selected node
-        if (this.state.links[index] && this.state.config.highlightDegree !== 0) {
-            Object.keys(this.state.links[index]).forEach(k => {
+        if (this.state.links[id] && this.state.config.highlightDegree !== 0) {
+            Object.keys(this.state.links[id]).forEach(k => {
                 this.state.nodes[k].highlighted = value;
             });
         }

--- a/src/components/graph/index.jsx
+++ b/src/components/graph/index.jsx
@@ -120,9 +120,9 @@ export default class Graph extends React.Component {
     /**
      * Sets nodes and links highlighted value.
      * @param  {number} index - the index of the node to highlight (and its adjacent).
-     * @param  {boolean} value - the highlight value to be set (true or false).
+     * @param  {boolean} [value=false] - the highlight value to be set (true or false).
      */
-    _setHighlighted = (index, value) => {
+    _setHighlighted = (index, value=false) => {
         this.state.highlightedNode = value ? index : '';
         this.state.nodes[index].highlighted = value;
 
@@ -190,6 +190,10 @@ export default class Graph extends React.Component {
         this.props.onMouseOutLink && this.props.onMouseOutLink(source, target);
 
         // this.state.config.highlightBehavior && this._setHighlighted(index, false);
+        if (this.state.config.highlightBehavior) {
+            this._setHighlighted(source, true);
+            this._setHighlighted(target, true);
+        }
     }
 
     /**
@@ -200,6 +204,10 @@ export default class Graph extends React.Component {
         this.props.onMouseOverLink && this.props.onMouseOverLink(source, target);
 
         // this.state.config.highlightBehavior && this._setHighlighted(index, true);
+        if (this.state.config.highlightBehavior) {
+            this._setHighlighted(source, true);
+            this._setHighlighted(target, true);
+        }
     }
 
     /**

--- a/src/components/graph/index.jsx
+++ b/src/components/graph/index.jsx
@@ -46,7 +46,7 @@ const D3_CONST = {
  *
  * // The graph configuration
  * const myConfig = {
- *     highlightBehavior: true,
+ *     nodeHighlightBehavior: true,
  *     node: {
  *         color: 'lightgreen',
  *         size: 120,
@@ -122,7 +122,7 @@ export default class Graph extends React.Component {
      * @param  {string} id - the id of the node to highlight.
      * @param  {boolean} [value=false] - the highlight value to be set (true or false).
      */
-    _setHighlighted = (id, value=false) => {
+    _setNodeHighlightedValue = (id, value=false) => {
         this.state.highlightedNode = value ? id : '';
         this.state.nodes[id].highlighted = value;
 
@@ -169,7 +169,7 @@ export default class Graph extends React.Component {
     onMouseOverNode = (id) => {
         this.props.onMouseOverNode && this.props.onMouseOverNode(id);
 
-        this.state.config.highlightBehavior && this._setHighlighted(id, true);
+        this.state.config.nodeHighlightBehavior && this._setNodeHighlightedValue(id, true);
     }
 
     /**
@@ -179,7 +179,7 @@ export default class Graph extends React.Component {
     onMouseOutNode = (id) => {
         this.props.onMouseOutNode && this.props.onMouseOutNode(id);
 
-        this.state.config.highlightBehavior && this._setHighlighted(id, false);
+        this.state.config.nodeHighlightBehavior && this._setNodeHighlightedValue(id, false);
     }
 
     /**
@@ -189,8 +189,7 @@ export default class Graph extends React.Component {
     onMouseOverLink = (source, target) => {
         this.props.onMouseOverLink && this.props.onMouseOverLink(source, target);
 
-        // this.state.config.highlightBehavior && this._setHighlighted(index, true);
-        if (this.state.config.highlightBehavior) {
+        if (this.state.config.linkHighlightBehavior) {
             this.state.highlightedLink = { source, target };
 
             this._tick();
@@ -204,8 +203,7 @@ export default class Graph extends React.Component {
     onMouseOutLink = (source, target) => {
         this.props.onMouseOutLink && this.props.onMouseOutLink(source, target);
 
-        // this.state.config.highlightBehavior && this._setHighlighted(index, false);
-        if (this.state.config.highlightBehavior) {
+        if (this.state.config.linkHighlightBehavior) {
             this.state.highlightedLink = undefined;
 
             this._tick();

--- a/src/components/graph/index.jsx
+++ b/src/components/graph/index.jsx
@@ -163,16 +163,6 @@ export default class Graph extends React.Component {
     }
 
     /**
-     * Handles mouse out node event.
-     * @param  {string} id - id of the node that participates in the event.
-     */
-    onMouseOutNode = (id) => {
-        this.props.onMouseOutNode && this.props.onMouseOutNode(id);
-
-        this.state.config.highlightBehavior && this._setHighlighted(id, false);
-    }
-
-    /**
      * Handles mouse over node event.
      * @param  {string} id - id of the node that participates in the event.
      */
@@ -183,19 +173,15 @@ export default class Graph extends React.Component {
     }
 
     /**
-     * Handles mouse out link event.
-     * @TODO
+     * Handles mouse out node event.
+     * @param  {string} id - id of the node that participates in the event.
      */
-    onMouseOutLink = (source, target) => {
-        this.props.onMouseOutLink && this.props.onMouseOutLink(source, target);
+    onMouseOutNode = (id) => {
+        this.props.onMouseOutNode && this.props.onMouseOutNode(id);
 
-        // this.state.config.highlightBehavior && this._setHighlighted(index, false);
-        if (this.state.config.highlightBehavior) {
-            this._setHighlighted(source, true);
-            this._setHighlighted(target, true);
-        }
+        this.state.config.highlightBehavior && this._setHighlighted(id, false);
     }
-
+    
     /**
      * Handles mouse over link event.
      * @TODO
@@ -207,6 +193,20 @@ export default class Graph extends React.Component {
         if (this.state.config.highlightBehavior) {
             this._setHighlighted(source, true);
             this._setHighlighted(target, true);
+        }
+    }
+
+    /**
+     * Handles mouse out link event.
+     * @TODO
+     */
+    onMouseOutLink = (source, target) => {
+        this.props.onMouseOutLink && this.props.onMouseOutLink(source, target);
+
+        // this.state.config.highlightBehavior && this._setHighlighted(index, false);
+        if (this.state.config.highlightBehavior) {
+            this._setHighlighted(source, false);
+            this._setHighlighted(target, false);
         }
     }
 

--- a/src/components/graph/index.jsx
+++ b/src/components/graph/index.jsx
@@ -311,7 +311,11 @@ export default class Graph extends React.Component {
                 onMouseOut: this.onMouseOutNode
             },
             this.state.links,
-            { onClickLink: this.props.onClickLink },
+            { 
+                onClickLink: this.props.onClickLink,
+                onMouseOverLink: this.props.onMouseOverLink,
+                onMouseOutLink: this.props.onMouseOutLink
+            },
             this.state.config,
             this.state.highlightedNode,
             this.state.transform

--- a/src/components/graph/index.jsx
+++ b/src/components/graph/index.jsx
@@ -183,6 +183,26 @@ export default class Graph extends React.Component {
     }
 
     /**
+     * Handles mouse out link event.
+     * @TODO
+     */
+    onMouseOutLink = (source, target) => {
+        this.props.onMouseOutLink && this.props.onMouseOutLink(source, target);
+
+        // this.state.config.highlightBehavior && this._setHighlighted(index, false);
+    }
+
+    /**
+     * Handles mouse over link event.
+     * @TODO
+     */
+    onMouseOverLink = (source, target) => {
+        this.props.onMouseOverLink && this.props.onMouseOverLink(source, target);
+
+        // this.state.config.highlightBehavior && this._setHighlighted(index, true);
+    }
+
+    /**
     * Calls d3 simulation.stop().<br/>
     * {@link https://github.com/d3/d3-force#simulation_stop}
     */
@@ -311,10 +331,10 @@ export default class Graph extends React.Component {
                 onMouseOut: this.onMouseOutNode
             },
             this.state.links,
-            { 
+            {
                 onClickLink: this.props.onClickLink,
-                onMouseOverLink: this.props.onMouseOverLink,
-                onMouseOutLink: this.props.onMouseOutLink
+                onMouseOverLink: this.onMouseOverLink,
+                onMouseOutLink: this.onMouseOutLink
             },
             this.state.config,
             this.state.highlightedNode,

--- a/src/components/link/index.jsx
+++ b/src/components/link/index.jsx
@@ -7,6 +7,14 @@ import React from 'react';
  *      window.alert(`Clicked link between ${source} and ${target}`);
  * };
  *
+ * const onMouseOverLink = function(source, target) {
+ *      window.alert(`Mouse over in link between ${source} and ${target}`);
+ * };
+ *
+ * const onMouseOutLink = function(source, target) {
+ *      window.alert(`Mouse out link between ${source} and ${target}`);
+ * };
+ *
  * <Link
  *     source='idSourceNode'
  *     target='idTargetNode'
@@ -18,7 +26,9 @@ import React from 'react';
  *     stroke='green'
  *     className='link'
  *     opacity=1
- *     onClickLink={onClickLink} />
+ *     onClickLink={onClickLink}
+ *     onMouseOverLink={onMouseOverLink}
+ *     onMouseOutLink={onMouseOutLink} />
  */
 export default class Link extends React.Component {
     /**
@@ -30,13 +40,13 @@ export default class Link extends React.Component {
     /**
      * Handle mouse over link event.
      */
-    handleOnMouseOverLink = () => this.props.onMouseOverLink 
+    handleOnMouseOverLink = () => this.props.onMouseOverLink
                             && this.props.onMouseOverLink(this.props.source, this.props.target);
 
     /**
      * Handle mouse out link event.
      */
-    handleOnMouseOutLink = () => this.props.onMouseOutLink 
+    handleOnMouseOutLink = () => this.props.onMouseOutLink
                             && this.props.onMouseOutLink(this.props.source, this.props.target);
 
     render() {

--- a/src/components/link/index.jsx
+++ b/src/components/link/index.jsx
@@ -24,17 +24,20 @@ export default class Link extends React.Component {
     /**
      * Handle link click event.
      */
-    handleOnClickLink = () => this.props.onClickLink && this.props.onClickLink(this.props.source, this.props.target);
+    handleOnClickLink = () => this.props.onClickLink
+                            && this.props.onClickLink(this.props.source, this.props.target);
 
     /**
      * Handle mouse over link event.
      */
-    handleOnMouseOverLink = () => this.props.onMouseOverLink && this.props.onMouseOverLink(this.props.source, this.props.target);
+    handleOnMouseOverLink = () => this.props.onMouseOverLink 
+                            && this.props.onMouseOverLink(this.props.source, this.props.target);
 
     /**
      * Handle mouse out link event.
      */
-    handleOnMouseOutLink = () => this.props.onMouseOutLink && this.props.onMouseOutLink(this.props.source, this.props.target);
+    handleOnMouseOutLink = () => this.props.onMouseOutLink 
+                            && this.props.onMouseOutLink(this.props.source, this.props.target);
 
     render() {
         const lineStyle = {

--- a/src/components/link/index.jsx
+++ b/src/components/link/index.jsx
@@ -26,6 +26,16 @@ export default class Link extends React.Component {
      */
     handleOnClickLink = () => this.props.onClickLink && this.props.onClickLink(this.props.source, this.props.target);
 
+    /**
+     * Handle mouse over link event.
+     */
+    handleOnMouseOverLink = () => this.props.onMouseOverLink && this.props.onMouseOverLink(this.props.source, this.props.target);
+
+    /**
+     * Handle mouse out link event.
+     */
+    handleOnMouseOutLink = () => this.props.onMouseOutLink && this.props.onMouseOutLink(this.props.source, this.props.target);
+
     render() {
         const lineStyle = {
             strokeWidth: this.props.strokeWidth,
@@ -36,6 +46,8 @@ export default class Link extends React.Component {
         const lineProps = {
             className: this.props.className,
             onClick: this.handleOnClickLink,
+            onMouseOut: this.handleOnMouseOutLink,
+            onMouseOver: this.handleOnMouseOverLink,
             style: lineStyle,
             x1: this.props.x1,
             x2: this.props.x2,
@@ -44,7 +56,7 @@ export default class Link extends React.Component {
         };
 
         return (
-            <line {...lineProps}/>
+            <line {...lineProps} />
         );
     }
 }

--- a/src/err.js
+++ b/src/err.js
@@ -3,5 +3,7 @@ export default {
     STATIC_GRAPH_DATA_UPDATE: "a static graph cannot receive new data (nodes or links).\
     Make sure config.staticGraph is set to true if you want to update graph data",
     INVALID_LINKS: "you provided a invalid links data structure.\
-    Links source and target attributes must point to an existent node"
+    Links source and target attributes must point to an existent node",
+    INSUFFICIENT_DATA: "you have not provided enough data for react-d3-graph to render something.\
+    You need to provide at least one node"
 };

--- a/test/Graph.test.js
+++ b/test/Graph.test.js
@@ -14,7 +14,7 @@ describe('Graph Component', () => {
     that.config = {
         height: that.svgSize,
         width: that.svgSize,
-        highlightBehavior: true,
+        nodeHighlightBehavior: true,
         highlightOpacity: that.highlightOpacity,
         staticGraph: true,
         node: {

--- a/test/__snapshots__/Graph.test.js.snap
+++ b/test/__snapshots__/Graph.test.js.snap
@@ -18,6 +18,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -33,6 +35,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -48,6 +52,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -63,6 +69,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -78,6 +86,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -93,6 +103,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -108,6 +120,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -123,6 +137,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -138,6 +154,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -153,6 +171,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -168,6 +188,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -183,6 +205,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -198,6 +222,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -213,6 +239,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -228,6 +256,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -243,6 +273,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -258,6 +290,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -273,6 +307,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -288,6 +324,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -303,6 +341,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -318,6 +358,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -333,6 +375,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -348,6 +392,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -363,6 +409,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -378,6 +426,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -393,6 +443,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -408,6 +460,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -423,6 +477,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -438,6 +494,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -453,6 +511,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -468,6 +528,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -483,6 +545,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -498,6 +562,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -513,6 +579,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -528,6 +596,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -543,6 +613,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -558,6 +630,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -573,6 +647,8 @@ exports[`Graph Component should be properly rendered 1`] = `
       <line
         className="link"
         onClick={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
         style={
           Object {
             "opacity": 1,

--- a/test/__snapshots__/Link.test.js.snap
+++ b/test/__snapshots__/Link.test.js.snap
@@ -4,6 +4,8 @@ exports[`Link Component should be properly rendered 1`] = `
 <line
   className={undefined}
   onClick={[Function]}
+  onMouseOut={[Function]}
+  onMouseOver={[Function]}
   style={
     Object {
       "opacity": "1",


### PR DESCRIPTION
This feature exposes new callback props so that clients can be notified when mouse over/out link elements occur. Furthermore, a new highlight mechanism was implemented, now similar to the behavior of the node we get a link highlight behavior. To activate this behavior one needs only to turn on the config flag `linkHighlightBehavior` that is false by default. <small>(below a sample GIF with the developed functionality)</small>

![node-link-highlight](https://user-images.githubusercontent.com/11733994/33225748-8a7af6ce-d175-11e7-837d-bf4597830260.gif)

Also, notice that upon next release a breaking change will be introduced since old config `highlightBehavior` is now broken into `nodeHighlightBehavior` (for mouse over/out nodes) and `linkHighlightBehavior` (for link highlight behavior).

Feature request based on https://github.com/danielcaldas/react-d3-graph/issues/25