### PR TITLE
Move logic from graph component (highlight updates)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
     verbose: true,
-    rootDir: 'test'
+    rootDir: '.',
+    collectCoverageFrom: ['src/**/*.{js,jsx}']
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
             "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
             "dev": true,
             "requires": {
-                "chalk": "2.3.2",
+                "chalk": "2.4.0",
                 "esutils": "2.0.2",
                 "js-tokens": "3.0.2"
             },
@@ -84,14 +84,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "has-flag": {
@@ -101,9 +101,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -350,6 +350,13 @@
             "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
             "dev": true
         },
+        "abbrev": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+            "dev": true,
+            "optional": true
+        },
         "accepts": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
@@ -511,6 +518,17 @@
             "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
             "dev": true
         },
+        "are-we-there-yet": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+            "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "delegates": "1.0.0",
+                "readable-stream": "2.3.6"
+            }
+        },
         "argparse": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -579,9 +597,9 @@
             }
         },
         "array-iterate": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-1.1.1.tgz",
-            "integrity": "sha1-hlv3+K851rCYLGCQKRSsdrwBCPY=",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-1.1.2.tgz",
+            "integrity": "sha512-1hWSHTIlG/8wtYD+PPX5AOBtKWngpDFjrsrHgZpe+JdgNGz0udYu6ZIkAa/xuenIUEqFv7DvE2Yr60jxweJSrQ==",
             "dev": true
         },
         "array-map": {
@@ -718,7 +736,7 @@
             "dev": true,
             "requires": {
                 "browserslist": "1.7.7",
-                "caniuse-db": "1.0.30000827",
+                "caniuse-db": "1.0.30000830",
                 "normalize-range": "0.1.2",
                 "num2fraction": "1.2.2",
                 "postcss": "5.2.18",
@@ -731,7 +749,7 @@
                     "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
                     "dev": true,
                     "requires": {
-                        "caniuse-db": "1.0.30000827",
+                        "caniuse-db": "1.0.30000830",
                         "electron-to-chromium": "1.3.42"
                     }
                 }
@@ -821,7 +839,7 @@
                     "requires": {
                         "anymatch": "1.3.2",
                         "async-each": "1.0.1",
-                        "fsevents": "1.1.3",
+                        "fsevents": "1.2.0",
                         "glob-parent": "2.0.0",
                         "inherits": "2.0.3",
                         "is-binary-path": "1.0.1",
@@ -949,9 +967,9 @@
             }
         },
         "babel-eslint": {
-            "version": "8.2.2",
-            "resolved": "http://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.2.tgz",
-            "integrity": "sha512-Qt2lz2egBxNYWqN9JIO2z4NOOf8i4b5JS6CFoYrOZZTDssueiV1jH/jsefyg+86SeNY3rB361/mi3kE1WK2WYQ==",
+            "version": "8.2.3",
+            "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.3.tgz",
+            "integrity": "sha512-0HeSTtaXg/Em7FCUWxwOT+KeFSO1O7LuRuzhk7g+1BjwdlQGlHq4OyMi3GqGxrNfEq8jEi6Hmt5ylEQUhurgiQ==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "7.0.0-beta.44",
@@ -2038,9 +2056,9 @@
             "dev": true
         },
         "bail": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.2.tgz",
-            "integrity": "sha1-99bBcxYwqfnw1NNe0fli4gdKF2Q=",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.3.tgz",
+            "integrity": "sha512-1X8CnjFVQ+a+KW36uBNMTU5s8+v5FzeqrP7hTG5aTb4aPreSbZJlhwPon9VKMuEVgV++JM+SQrALY3kr7eswdg==",
             "dev": true
         },
         "balanced-match": {
@@ -2117,9 +2135,9 @@
             "dev": true
         },
         "base64-js": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
-            "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+            "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
             "dev": true
         },
         "batch": {
@@ -2438,7 +2456,7 @@
             "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "1.0.30000827",
+                "caniuse-lite": "1.0.30000830",
                 "electron-to-chromium": "1.3.42"
             }
         },
@@ -2457,7 +2475,7 @@
             "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
             "dev": true,
             "requires": {
-                "base64-js": "1.2.3",
+                "base64-js": "1.3.0",
                 "ieee754": "1.1.11",
                 "isarray": "1.0.0"
             }
@@ -2672,7 +2690,7 @@
             "dev": true,
             "requires": {
                 "browserslist": "1.7.7",
-                "caniuse-db": "1.0.30000827",
+                "caniuse-db": "1.0.30000830",
                 "lodash.memoize": "4.1.2",
                 "lodash.uniq": "4.5.0"
             },
@@ -2683,22 +2701,22 @@
                     "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
                     "dev": true,
                     "requires": {
-                        "caniuse-db": "1.0.30000827",
+                        "caniuse-db": "1.0.30000830",
                         "electron-to-chromium": "1.3.42"
                     }
                 }
             }
         },
         "caniuse-db": {
-            "version": "1.0.30000827",
-            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000827.tgz",
-            "integrity": "sha1-vSg53Rlgk7RMKMF/k1ExQMnZJYg=",
+            "version": "1.0.30000830",
+            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000830.tgz",
+            "integrity": "sha1-bkUlWzRWSf0V/1kHLaHhK7PeLxM=",
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30000827",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000827.tgz",
-            "integrity": "sha512-j9Q9hP5AhqOARNP6fLdctr3XrGhF921sBSycudf4E+8RCWpFT3rJdTfp/5o8LDp6p0NJTpYWEpBFiM+QEDzA6g==",
+            "version": "1.0.30000830",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000830.tgz",
+            "integrity": "sha512-yMqGkujkoOIZfvOYiWdqPALgY/PVGiqCHUJb6yNq7xhI/pR+gQO0U2K6lRDqAiJv4+CIU3CtTLblNGw0QGnr6g==",
             "dev": true
         },
         "caseless": {
@@ -2708,9 +2726,9 @@
             "dev": true
         },
         "ccount": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.2.tgz",
-            "integrity": "sha1-U7ai+BW7d7nChx97mnLDol8djok=",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.3.tgz",
+            "integrity": "sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw==",
             "dev": true
         },
         "center-align": {
@@ -2737,27 +2755,27 @@
             }
         },
         "character-entities": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.1.tgz",
-            "integrity": "sha1-92hxvl72bdt/j440eOzDdMJ9bco=",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.2.tgz",
+            "integrity": "sha512-sMoHX6/nBiy3KKfC78dnEalnpn0Az0oSNvqUWYTtYrhRI5iUIYsROU48G+E+kMFQzqXaJ8kHJZ85n7y6/PHgwQ==",
             "dev": true
         },
         "character-entities-html4": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.1.tgz",
-            "integrity": "sha1-NZoqSg9+KdPcKsmb2+Ie45Q46lA=",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.2.tgz",
+            "integrity": "sha512-sIrXwyna2+5b0eB9W149izTPJk/KkJTg6mEzDGibwBUkyH1SbDa+nf515Ppdi3MaH35lW0JFJDWeq9Luzes1Iw==",
             "dev": true
         },
         "character-entities-legacy": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.1.tgz",
-            "integrity": "sha1-9Ad53xoQGHK7UQo9KV4fzPFHIC8=",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.2.tgz",
+            "integrity": "sha512-9NB2VbXtXYWdXzqrvAHykE/f0QJxzaKIpZ5QzNZrrgQ7Iyxr2vnfS8fCBNVW9nUEZE0lo57nxKRqnzY/dKrwlA==",
             "dev": true
         },
         "character-reference-invalid": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.1.tgz",
-            "integrity": "sha1-lCg191Dk7GGjCOYMLvjMEBEgLvw=",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz",
+            "integrity": "sha512-7I/xceXfKyUJmSAn/jw8ve/9DyOP7XxufNYLI9Px7CmsKgEUaZLUTax6nZxGQtaoiZCjpu6cHPj20xC/vqRReQ==",
             "dev": true
         },
         "chardet": {
@@ -2781,7 +2799,7 @@
                 "anymatch": "2.0.0",
                 "async-each": "1.0.1",
                 "braces": "2.3.2",
-                "fsevents": "1.1.3",
+                "fsevents": "1.2.0",
                 "glob-parent": "3.1.0",
                 "inherits": "2.0.3",
                 "is-binary-path": "1.0.1",
@@ -2799,9 +2817,9 @@
             "dev": true
         },
         "chrome-trace-event": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-0.1.2.tgz",
-            "integrity": "sha1-kPNohdU0WlBiEzLwcXtZWIPV2YI=",
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-0.1.3.tgz",
+            "integrity": "sha512-sjndyZHrrWiu4RY7AkHgjn80GfAM2ZSzUkZLV/Js59Ldmh6JDThf0SUmOHU53rFu2rVxxfCzJ30Ukcfch3Gb/A==",
             "dev": true
         },
         "ci-info": {
@@ -2907,19 +2925,6 @@
             "requires": {
                 "slice-ansi": "0.0.4",
                 "string-width": "1.0.2"
-            },
-            "dependencies": {
-                "string-width": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                    "dev": true,
-                    "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
-                    }
-                }
             }
         },
         "cli-width": {
@@ -2999,9 +3004,9 @@
             "dev": true
         },
         "collapse-white-space": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.3.tgz",
-            "integrity": "sha1-S5BvZw5aljqHt2sOFolkM0G2Ajw=",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.4.tgz",
+            "integrity": "sha512-YfQ1tAUZm561vpYD+5eyWN8+UsceQbSrqqlc/6zDY2gtAE+uZLSdkkovhnGpmCThsvKBFakq4EdY/FF93E8XIw==",
             "dev": true
         },
         "collection-visit": {
@@ -3076,9 +3081,9 @@
             }
         },
         "comma-separated-tokens": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.4.tgz",
-            "integrity": "sha1-cgg+WNSkYvAYZvZhf02Yo807ikY=",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.5.tgz",
+            "integrity": "sha512-Cg90/fcK93n0ecgYTAz1jaA3zvnQ0ExlmKY1rdbyHqAx6BHxwoJc+J7HDu0iuQ7ixEs1qaa+WyQ6oeuBpYP1iA==",
             "dev": true,
             "requires": {
                 "trim": "0.0.1"
@@ -3245,6 +3250,12 @@
                 "date-now": "0.1.4"
             }
         },
+        "console-control-strings": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+            "dev": true
+        },
         "constants-browserify": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
@@ -3389,7 +3400,7 @@
                 "cipher-base": "1.0.4",
                 "inherits": "2.0.3",
                 "md5.js": "1.3.4",
-                "ripemd160": "2.0.1",
+                "ripemd160": "2.0.2",
                 "sha.js": "2.4.11"
             }
         },
@@ -3402,7 +3413,7 @@
                 "cipher-base": "1.0.4",
                 "create-hash": "1.2.0",
                 "inherits": "2.0.3",
-                "ripemd160": "2.0.1",
+                "ripemd160": "2.0.2",
                 "safe-buffer": "5.1.1",
                 "sha.js": "2.4.11"
             }
@@ -3450,7 +3461,7 @@
                 "create-hmac": "1.1.7",
                 "diffie-hellman": "5.0.3",
                 "inherits": "2.0.3",
-                "pbkdf2": "3.0.14",
+                "pbkdf2": "3.0.16",
                 "public-encrypt": "4.0.2",
                 "randombytes": "2.0.6",
                 "randomfill": "1.0.4"
@@ -4198,6 +4209,13 @@
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
             "dev": true
         },
+        "delegates": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+            "dev": true,
+            "optional": true
+        },
         "depd": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -4243,6 +4261,13 @@
             "requires": {
                 "repeating": "2.0.1"
             }
+        },
+        "detect-libc": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+            "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+            "dev": true,
+            "optional": true
         },
         "detect-newline": {
             "version": "2.1.0",
@@ -4355,7 +4380,7 @@
                 "babel-types": "6.26.0",
                 "babelify": "7.3.0",
                 "babylon": "6.18.0",
-                "chalk": "2.3.2",
+                "chalk": "2.4.0",
                 "chokidar": "1.7.0",
                 "concat-stream": "1.6.0",
                 "disparity": "2.0.0",
@@ -4468,14 +4493,14 @@
                     "dev": true
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "chokidar": {
@@ -4486,7 +4511,7 @@
                     "requires": {
                         "anymatch": "1.3.2",
                         "async-each": "1.0.1",
-                        "fsevents": "1.1.3",
+                        "fsevents": "1.2.0",
                         "glob-parent": "2.0.0",
                         "inherits": "2.0.3",
                         "is-binary-path": "1.0.1",
@@ -4649,17 +4674,6 @@
                         "path-type": "1.1.0"
                     }
                 },
-                "string-width": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                    "dev": true,
-                    "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
-                    }
-                },
                 "strip-bom": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
@@ -4670,9 +4684,9 @@
                     }
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -4879,9 +4893,9 @@
             "dev": true
         },
         "ejs": {
-            "version": "2.5.8",
-            "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.8.tgz",
-            "integrity": "sha512-QIDZL54fyV8MDcAsO91BMH1ft2qGGaHIJsJIA/+t+7uvXol1dm413fPcUgUb4k8F/9457rx4/KFE4XfDifrQxQ==",
+            "version": "2.5.9",
+            "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.9.tgz",
+            "integrity": "sha512-GJCAeDBKfREgkBtgrYSf9hQy9kTb3helv0zGdzqhM7iAkW8FA/ZF97VQDbwFiwIT8MQLLOe5VlPZOEvZAqtUAQ==",
             "dev": true
         },
         "electron-to-chromium": {
@@ -5157,7 +5171,7 @@
             "requires": {
                 "ajv": "5.5.2",
                 "babel-code-frame": "6.26.0",
-                "chalk": "2.3.2",
+                "chalk": "2.4.0",
                 "concat-stream": "1.6.0",
                 "cross-spawn": "5.1.0",
                 "debug": "3.1.0",
@@ -5211,14 +5225,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "esprima": {
@@ -5265,9 +5279,9 @@
                     }
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -5281,10 +5295,10 @@
             "integrity": "sha1-PWyeh+0KDucvJ5cTjrC86yCJfKI=",
             "dev": true,
             "requires": {
-                "babel-eslint": "8.2.2",
+                "babel-eslint": "8.2.3",
                 "eslint": "4.19.1",
                 "eslint-plugin-babel": "4.1.2",
-                "eslint-plugin-import": "2.10.0"
+                "eslint-plugin-import": "2.11.0"
             }
         },
         "eslint-config-recommended": {
@@ -5293,11 +5307,11 @@
             "integrity": "sha1-I1gX/da6j7A8/eOZWunm64+Y51Q=",
             "dev": true,
             "requires": {
-                "babel-eslint": "8.2.2",
+                "babel-eslint": "8.2.3",
                 "eslint": "4.19.1",
                 "eslint-config-esnext": "2.0.0",
                 "eslint-plugin-babel": "4.1.2",
-                "eslint-plugin-import": "2.10.0",
+                "eslint-plugin-import": "2.11.0",
                 "eslint-plugin-react": "7.7.0",
                 "eslint-plugin-react-native": "3.2.1"
             }
@@ -5309,7 +5323,7 @@
             "dev": true,
             "requires": {
                 "debug": "2.6.9",
-                "resolve": "1.7.0"
+                "resolve": "1.7.1"
             },
             "dependencies": {
                 "debug": {
@@ -5379,12 +5393,11 @@
             "dev": true
         },
         "eslint-plugin-import": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.10.0.tgz",
-            "integrity": "sha1-+gkIPVp1KI35xsfQn+EiVZhWVec=",
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.11.0.tgz",
+            "integrity": "sha1-Fa7qN6Z0mdhI6OmBgG1GJ7VQOBY=",
             "dev": true,
             "requires": {
-                "builtin-modules": "1.1.1",
                 "contains-path": "0.1.0",
                 "debug": "2.6.9",
                 "doctrine": "1.5.0",
@@ -5393,7 +5406,8 @@
                 "has": "1.0.1",
                 "lodash": "4.17.5",
                 "minimatch": "3.0.4",
-                "read-pkg-up": "2.0.0"
+                "read-pkg-up": "2.0.0",
+                "resolve": "1.7.1"
             },
             "dependencies": {
                 "debug": {
@@ -5556,9 +5570,9 @@
             }
         },
         "eventemitter3": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
-            "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.0.1.tgz",
+            "integrity": "sha512-QOCPu979MMWX9XNlfRZoin+Wm+bK1SP7vv3NGUniYwuSJK/+cPA10blMaeRgzg31RvoSFk6FsCDVa4vNryBTGA==",
             "dev": true
         },
         "events": {
@@ -6171,9 +6185,9 @@
             "dev": true
         },
         "flow-parser": {
-            "version": "0.69.0",
-            "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.69.0.tgz",
-            "integrity": "sha1-N4tRKNbQtVSosvFqTKPhq5ZJ8A4=",
+            "version": "0.70.0",
+            "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.70.0.tgz",
+            "integrity": "sha512-gGdyVUZWswG5jcINrVDHd3RY4nJptBTAx9mR9thGsrGGmAUR7omgJXQSpR+fXrLtxSTAea3HpAZNU/yzRJc2Cg==",
             "dev": true
         },
         "flush-write-stream": {
@@ -6184,6 +6198,15 @@
             "requires": {
                 "inherits": "2.0.3",
                 "readable-stream": "2.3.6"
+            }
+        },
+        "follow-redirects": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
+            "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
+            "dev": true,
+            "requires": {
+                "debug": "3.1.0"
             }
         },
         "for-in": {
@@ -6272,6 +6295,16 @@
                 "universalify": "0.1.1"
             }
         },
+        "fs-minipass": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+            "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "minipass": "2.2.4"
+            }
+        },
         "fs-readdir-recursive": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
@@ -6297,27 +6330,23 @@
             "dev": true
         },
         "fsevents": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
-            "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.0.tgz",
+            "integrity": "sha512-ROrBIbmw4ulxmQTwYAAGyN/0xgIOAFd6gX/K3F1aGLP/K5KxkubrlGISMV5EEWEB7qtiEdE0HpaqvMMHR+Ib6w==",
             "dev": true,
             "optional": true,
             "requires": {
                 "nan": "2.10.0",
-                "node-pre-gyp": "0.6.39"
+                "node-pre-gyp": "0.9.1"
             },
             "dependencies": {
                 "abbrev": {
                     "version": "1.1.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "ajv": {
                     "version": "4.11.8",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true,
                     "requires": {
                         "co": "4.6.0",
                         "json-stable-stringify": "1.0.1"
@@ -6325,20 +6354,15 @@
                 },
                 "ansi-regex": {
                     "version": "2.1.1",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "aproba": {
                     "version": "1.1.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "are-we-there-yet": {
                     "version": "1.1.4",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true,
                     "requires": {
                         "delegates": "1.0.0",
                         "readable-stream": "2.2.9"
@@ -6346,43 +6370,31 @@
                 },
                 "asn1": {
                     "version": "0.2.3",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "assert-plus": {
                     "version": "0.2.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "asynckit": {
                     "version": "0.4.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "aws-sign2": {
                     "version": "0.6.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "aws4": {
                     "version": "1.6.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "balanced-match": {
                     "version": "0.4.2",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "bcrypt-pbkdf": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "tweetnacl": "0.14.5"
@@ -6391,7 +6403,6 @@
                 "block-stream": {
                     "version": "0.0.9",
                     "bundled": true,
-                    "dev": true,
                     "requires": {
                         "inherits": "2.0.3"
                     }
@@ -6399,7 +6410,6 @@
                 "boom": {
                     "version": "2.10.1",
                     "bundled": true,
-                    "dev": true,
                     "requires": {
                         "hoek": "2.16.3"
                     }
@@ -6407,7 +6417,6 @@
                 "brace-expansion": {
                     "version": "1.1.7",
                     "bundled": true,
-                    "dev": true,
                     "requires": {
                         "balanced-match": "0.4.2",
                         "concat-map": "0.0.1"
@@ -6415,53 +6424,42 @@
                 },
                 "buffer-shims": {
                     "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "caseless": {
                     "version": "0.12.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "co": {
                     "version": "4.6.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "code-point-at": {
                     "version": "1.1.0",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "combined-stream": {
                     "version": "1.0.5",
                     "bundled": true,
-                    "dev": true,
                     "requires": {
                         "delayed-stream": "1.0.0"
                     }
                 },
                 "concat-map": {
                     "version": "0.0.1",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "cryptiles": {
                     "version": "2.0.5",
                     "bundled": true,
-                    "dev": true,
                     "requires": {
                         "boom": "2.10.1"
                     }
@@ -6469,56 +6467,42 @@
                 "dashdash": {
                     "version": "1.14.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true,
                     "requires": {
                         "assert-plus": "1.0.0"
                     },
                     "dependencies": {
                         "assert-plus": {
                             "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
+                            "bundled": true
                         }
                     }
                 },
                 "debug": {
                     "version": "2.6.8",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
                 },
                 "deep-extend": {
                     "version": "0.4.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "delayed-stream": {
                     "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "delegates": {
                     "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "detect-libc": {
                     "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "ecc-jsbn": {
                     "version": "0.1.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "jsbn": "0.1.1"
@@ -6526,26 +6510,19 @@
                 },
                 "extend": {
                     "version": "3.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "extsprintf": {
                     "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "forever-agent": {
                     "version": "0.6.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "form-data": {
                     "version": "2.1.4",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true,
                     "requires": {
                         "asynckit": "0.4.0",
                         "combined-stream": "1.0.5",
@@ -6554,13 +6531,11 @@
                 },
                 "fs.realpath": {
                     "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "fstream": {
                     "version": "1.0.11",
                     "bundled": true,
-                    "dev": true,
                     "requires": {
                         "graceful-fs": "4.1.11",
                         "inherits": "2.0.3",
@@ -6571,8 +6546,6 @@
                 "fstream-ignore": {
                     "version": "1.0.5",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true,
                     "requires": {
                         "fstream": "1.0.11",
                         "inherits": "2.0.3",
@@ -6582,8 +6555,6 @@
                 "gauge": {
                     "version": "2.7.4",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true,
                     "requires": {
                         "aproba": "1.1.1",
                         "console-control-strings": "1.1.0",
@@ -6598,24 +6569,19 @@
                 "getpass": {
                     "version": "0.1.7",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true,
                     "requires": {
                         "assert-plus": "1.0.0"
                     },
                     "dependencies": {
                         "assert-plus": {
                             "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
+                            "bundled": true
                         }
                     }
                 },
                 "glob": {
                     "version": "7.1.2",
                     "bundled": true,
-                    "dev": true,
                     "requires": {
                         "fs.realpath": "1.0.0",
                         "inflight": "1.0.6",
@@ -6627,20 +6593,15 @@
                 },
                 "graceful-fs": {
                     "version": "4.1.11",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "har-schema": {
                     "version": "1.0.5",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "har-validator": {
                     "version": "4.2.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true,
                     "requires": {
                         "ajv": "4.11.8",
                         "har-schema": "1.0.5"
@@ -6648,14 +6609,11 @@
                 },
                 "has-unicode": {
                     "version": "2.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "hawk": {
                     "version": "3.1.3",
                     "bundled": true,
-                    "dev": true,
                     "requires": {
                         "boom": "2.10.1",
                         "cryptiles": "2.0.5",
@@ -6665,14 +6623,11 @@
                 },
                 "hoek": {
                     "version": "2.16.3",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "http-signature": {
                     "version": "1.1.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true,
                     "requires": {
                         "assert-plus": "0.2.0",
                         "jsprim": "1.4.0",
@@ -6682,7 +6637,6 @@
                 "inflight": {
                     "version": "1.0.6",
                     "bundled": true,
-                    "dev": true,
                     "requires": {
                         "once": "1.4.0",
                         "wrappy": "1.0.2"
@@ -6690,44 +6644,34 @@
                 },
                 "inherits": {
                     "version": "2.0.3",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "ini": {
                     "version": "1.3.4",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true,
                     "requires": {
                         "number-is-nan": "1.0.1"
                     }
                 },
                 "is-typedarray": {
                     "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "isarray": {
                     "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "isstream": {
                     "version": "0.1.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "jodid25519": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "jsbn": "0.1.1"
@@ -6736,41 +6680,30 @@
                 "jsbn": {
                     "version": "0.1.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "json-schema": {
                     "version": "0.2.3",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "json-stable-stringify": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true,
                     "requires": {
                         "jsonify": "0.0.0"
                     }
                 },
                 "json-stringify-safe": {
                     "version": "5.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "jsonify": {
                     "version": "0.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "jsprim": {
                     "version": "1.4.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true,
                     "requires": {
                         "assert-plus": "1.0.0",
                         "extsprintf": "1.0.2",
@@ -6780,21 +6713,17 @@
                     "dependencies": {
                         "assert-plus": {
                             "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
+                            "bundled": true
                         }
                     }
                 },
                 "mime-db": {
                     "version": "1.27.0",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "mime-types": {
                     "version": "2.1.15",
                     "bundled": true,
-                    "dev": true,
                     "requires": {
                         "mime-db": "1.27.0"
                     }
@@ -6802,54 +6731,28 @@
                 "minimatch": {
                     "version": "3.0.4",
                     "bundled": true,
-                    "dev": true,
                     "requires": {
                         "brace-expansion": "1.1.7"
                     }
                 },
                 "minimist": {
                     "version": "0.0.8",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "mkdirp": {
                     "version": "0.5.1",
                     "bundled": true,
-                    "dev": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
                 },
                 "ms": {
                     "version": "2.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "node-pre-gyp": {
-                    "version": "0.6.39",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "detect-libc": "1.0.2",
-                        "hawk": "3.1.3",
-                        "mkdirp": "0.5.1",
-                        "nopt": "4.0.1",
-                        "npmlog": "4.1.0",
-                        "rc": "1.2.1",
-                        "request": "2.81.0",
-                        "rimraf": "2.6.1",
-                        "semver": "5.3.0",
-                        "tar": "2.2.1",
-                        "tar-pack": "3.4.0"
-                    }
+                    "bundled": true
                 },
                 "nopt": {
                     "version": "4.0.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true,
                     "requires": {
                         "abbrev": "1.1.0",
                         "osenv": "0.1.4"
@@ -6858,8 +6761,6 @@
                 "npmlog": {
                     "version": "4.1.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true,
                     "requires": {
                         "are-we-there-yet": "1.1.4",
                         "console-control-strings": "1.1.0",
@@ -6869,46 +6770,34 @@
                 },
                 "number-is-nan": {
                     "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "oauth-sign": {
                     "version": "0.8.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "once": {
                     "version": "1.4.0",
                     "bundled": true,
-                    "dev": true,
                     "requires": {
                         "wrappy": "1.0.2"
                     }
                 },
                 "os-homedir": {
                     "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "os-tmpdir": {
                     "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "osenv": {
                     "version": "0.1.4",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true,
                     "requires": {
                         "os-homedir": "1.0.2",
                         "os-tmpdir": "1.0.2"
@@ -6916,37 +6805,27 @@
                 },
                 "path-is-absolute": {
                     "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "performance-now": {
                     "version": "0.2.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "process-nextick-args": {
                     "version": "1.0.7",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "punycode": {
                     "version": "1.4.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "qs": {
                     "version": "6.4.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "rc": {
                     "version": "1.2.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true,
                     "requires": {
                         "deep-extend": "0.4.2",
                         "ini": "1.3.4",
@@ -6956,16 +6835,13 @@
                     "dependencies": {
                         "minimist": {
                             "version": "1.2.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
+                            "bundled": true
                         }
                     }
                 },
                 "readable-stream": {
                     "version": "2.2.9",
                     "bundled": true,
-                    "dev": true,
                     "requires": {
                         "buffer-shims": "1.0.0",
                         "core-util-is": "1.0.2",
@@ -6979,8 +6855,6 @@
                 "request": {
                     "version": "2.81.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true,
                     "requires": {
                         "aws-sign2": "0.6.0",
                         "aws4": "1.6.0",
@@ -7009,38 +6883,29 @@
                 "rimraf": {
                     "version": "2.6.1",
                     "bundled": true,
-                    "dev": true,
                     "requires": {
                         "glob": "7.1.2"
                     }
                 },
                 "safe-buffer": {
                     "version": "5.0.1",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "semver": {
                     "version": "5.3.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "set-blocking": {
                     "version": "2.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "signal-exit": {
                     "version": "3.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "sntp": {
                     "version": "1.0.9",
                     "bundled": true,
-                    "dev": true,
                     "requires": {
                         "hoek": "2.16.3"
                     }
@@ -7048,8 +6913,6 @@
                 "sshpk": {
                     "version": "1.13.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true,
                     "requires": {
                         "asn1": "0.2.3",
                         "assert-plus": "1.0.0",
@@ -7064,16 +6927,13 @@
                     "dependencies": {
                         "assert-plus": {
                             "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
+                            "bundled": true
                         }
                     }
                 },
                 "string-width": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true,
                     "requires": {
                         "code-point-at": "1.1.0",
                         "is-fullwidth-code-point": "1.0.0",
@@ -7083,35 +6943,28 @@
                 "string_decoder": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true,
                     "requires": {
                         "safe-buffer": "5.0.1"
                     }
                 },
                 "stringstream": {
                     "version": "0.0.5",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
                     "bundled": true,
-                    "dev": true,
                     "requires": {
                         "ansi-regex": "2.1.1"
                     }
                 },
                 "strip-json-comments": {
                     "version": "2.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "tar": {
                     "version": "2.2.1",
                     "bundled": true,
-                    "dev": true,
                     "requires": {
                         "block-stream": "0.0.9",
                         "fstream": "1.0.11",
@@ -7121,8 +6974,6 @@
                 "tar-pack": {
                     "version": "3.4.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true,
                     "requires": {
                         "debug": "2.6.8",
                         "fstream": "1.0.11",
@@ -7137,8 +6988,6 @@
                 "tough-cookie": {
                     "version": "2.3.2",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true,
                     "requires": {
                         "punycode": "1.4.1"
                     }
@@ -7146,8 +6995,6 @@
                 "tunnel-agent": {
                     "version": "0.6.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true,
                     "requires": {
                         "safe-buffer": "5.0.1"
                     }
@@ -7155,31 +7002,23 @@
                 "tweetnacl": {
                     "version": "0.14.5",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "uid-number": {
                     "version": "0.0.6",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "util-deprecate": {
                     "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "uuid": {
                     "version": "3.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "verror": {
                     "version": "1.3.6",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true,
                     "requires": {
                         "extsprintf": "1.0.2"
                     }
@@ -7187,16 +7026,13 @@
                 "wide-align": {
                     "version": "1.1.2",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true,
                     "requires": {
                         "string-width": "1.0.2"
                     }
                 },
                 "wrappy": {
                     "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 }
             }
         },
@@ -7211,6 +7047,23 @@
             "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
             "dev": true
+        },
+        "gauge": {
+            "version": "2.7.4",
+            "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+            "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "aproba": "1.2.0",
+                "console-control-strings": "1.1.0",
+                "has-unicode": "2.0.1",
+                "object-assign": "4.1.1",
+                "signal-exit": "3.0.2",
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wide-align": "1.1.2"
+            }
         },
         "get-caller-file": {
             "version": "1.0.2",
@@ -7891,6 +7744,13 @@
                 "has-symbol-support-x": "1.4.2"
             }
         },
+        "has-unicode": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+            "dev": true,
+            "optional": true
+        },
         "has-value": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
@@ -7964,14 +7824,14 @@
             "integrity": "sha1-iCyZhJ5AEw6ZHAQuRW1FPZXDbP8=",
             "dev": true,
             "requires": {
-                "ccount": "1.0.2",
-                "comma-separated-tokens": "1.0.4",
+                "ccount": "1.0.3",
+                "comma-separated-tokens": "1.0.5",
                 "hast-util-is-element": "1.0.0",
                 "hast-util-whitespace": "1.0.0",
-                "html-void-elements": "1.0.2",
+                "html-void-elements": "1.0.3",
                 "kebab-case": "1.0.0",
                 "property-information": "3.2.0",
-                "space-separated-tokens": "1.1.1",
+                "space-separated-tokens": "1.1.2",
                 "stringify-entities": "1.3.1",
                 "unist-util-is": "2.1.1",
                 "xtend": "4.0.1"
@@ -8083,9 +7943,9 @@
             "dev": true
         },
         "html-minifier": {
-            "version": "3.5.14",
-            "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.14.tgz",
-            "integrity": "sha512-sZjw6zhQgyUnIlIPU+W80XpRjWjdxHtNcxjfyOskOsCTDKytcfLY04wsQY/83Yqb4ndoiD2FtauiL7Yg6uUQFQ==",
+            "version": "3.5.15",
+            "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.15.tgz",
+            "integrity": "sha512-OZa4rfb6tZOZ3Z8Xf0jKxXkiDcFWldQePGYFDcgKqES2sXeWaEv9y6QQvWUtX3ySI3feApQi5uCsHLINQ6NoAw==",
             "dev": true,
             "requires": {
                 "camel-case": "3.0.0",
@@ -8094,7 +7954,7 @@
                 "he": "1.1.1",
                 "param-case": "2.1.1",
                 "relateurl": "0.2.7",
-                "uglify-js": "3.3.20"
+                "uglify-js": "3.3.22"
             },
             "dependencies": {
                 "source-map": {
@@ -8104,9 +7964,9 @@
                     "dev": true
                 },
                 "uglify-js": {
-                    "version": "3.3.20",
-                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.20.tgz",
-                    "integrity": "sha512-WpLkWCf9sGvGZnIvBV0PNID9BATQNT/IXKAmqegfKzIPcTmTV3FP8NQpoogQkt/Y402x2sOFdaHUmqFY9IZp+g==",
+                    "version": "3.3.22",
+                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.22.tgz",
+                    "integrity": "sha512-tqw96rL6/BG+7LM5VItdhDjTQmL5zG/I0b2RqWytlgeHe2eydZHuBHdA9vuGpCDhH/ZskNGcqDhivoR2xt8RIw==",
                     "dev": true,
                     "requires": {
                         "commander": "2.15.1",
@@ -8116,9 +7976,9 @@
             }
         },
         "html-void-elements": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.2.tgz",
-            "integrity": "sha1-nSLgyjKsyVs/RbjVtPb73AWv/VU=",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.3.tgz",
+            "integrity": "sha512-SaGhCDPXJVNrQyKMtKy24q6IMdXg5FCPN3z+xizxw9l+oXQw5fOoaj/ERU5KqWhSYhXtW5bWthlDbTDLBhJQrA==",
             "dev": true
         },
         "html-webpack-plugin": {
@@ -8128,7 +7988,7 @@
             "dev": true,
             "requires": {
                 "bluebird": "3.5.0",
-                "html-minifier": "3.5.14",
+                "html-minifier": "3.5.15",
                 "loader-utils": "0.2.17",
                 "lodash": "4.17.5",
                 "pretty-error": "2.1.1",
@@ -8227,126 +8087,26 @@
             "dev": true
         },
         "http-proxy": {
-            "version": "1.16.2",
-            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
-            "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
+            "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
             "dev": true,
             "requires": {
-                "eventemitter3": "1.2.0",
+                "eventemitter3": "3.0.1",
+                "follow-redirects": "1.4.1",
                 "requires-port": "1.0.0"
             }
         },
         "http-proxy-middleware": {
-            "version": "0.17.4",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
-            "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
+            "integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
             "dev": true,
             "requires": {
-                "http-proxy": "1.16.2",
-                "is-glob": "3.1.0",
+                "http-proxy": "1.17.0",
+                "is-glob": "4.0.0",
                 "lodash": "4.17.5",
-                "micromatch": "2.3.11"
-            },
-            "dependencies": {
-                "arr-diff": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-                    "dev": true,
-                    "requires": {
-                        "arr-flatten": "1.1.0"
-                    }
-                },
-                "array-unique": {
-                    "version": "0.2.1",
-                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                    "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-                    "dev": true
-                },
-                "braces": {
-                    "version": "1.8.5",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-                    "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-                    "dev": true,
-                    "requires": {
-                        "expand-range": "1.8.2",
-                        "preserve": "0.2.0",
-                        "repeat-element": "1.1.2"
-                    }
-                },
-                "expand-brackets": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-                    "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-                    "dev": true,
-                    "requires": {
-                        "is-posix-bracket": "0.1.1"
-                    }
-                },
-                "extglob": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-                    "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "1.0.0"
-                    },
-                    "dependencies": {
-                        "is-extglob": {
-                            "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                            "dev": true
-                        }
-                    }
-                },
-                "is-glob": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "2.1.1"
-                    }
-                },
-                "micromatch": {
-                    "version": "2.3.11",
-                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-                    "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-                    "dev": true,
-                    "requires": {
-                        "arr-diff": "2.0.0",
-                        "array-unique": "0.2.1",
-                        "braces": "1.8.5",
-                        "expand-brackets": "0.1.5",
-                        "extglob": "0.3.2",
-                        "filename-regex": "2.0.1",
-                        "is-extglob": "1.0.0",
-                        "is-glob": "2.0.1",
-                        "kind-of": "3.2.2",
-                        "normalize-path": "2.1.1",
-                        "object.omit": "2.0.1",
-                        "parse-glob": "3.0.4",
-                        "regex-cache": "0.4.4"
-                    },
-                    "dependencies": {
-                        "is-extglob": {
-                            "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                            "dev": true
-                        },
-                        "is-glob": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                            "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                            "dev": true,
-                            "requires": {
-                                "is-extglob": "1.0.0"
-                            }
-                        }
-                    }
-                }
+                "micromatch": "3.1.10"
             }
         },
         "http-server": {
@@ -8358,7 +8118,7 @@
                 "colors": "1.0.3",
                 "corser": "2.0.1",
                 "ecstatic": "3.2.0",
-                "http-proxy": "1.16.2",
+                "http-proxy": "1.17.0",
                 "opener": "1.4.3",
                 "optimist": "0.6.1",
                 "portfinder": "1.0.13",
@@ -8442,14 +8202,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "has-flag": {
@@ -8464,9 +8224,9 @@
                     "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.3.2",
+                        "chalk": "2.4.0",
                         "source-map": "0.6.1",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "source-map": {
@@ -8476,9 +8236,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -8503,6 +8263,16 @@
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
             "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
             "dev": true
+        },
+        "ignore-walk": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+            "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "minimatch": "3.0.4"
+            }
         },
         "import-local": {
             "version": "1.0.0",
@@ -8570,7 +8340,7 @@
             "dev": true,
             "requires": {
                 "ansi-escapes": "3.1.0",
-                "chalk": "2.3.2",
+                "chalk": "2.4.0",
                 "cli-cursor": "2.1.0",
                 "cli-width": "2.2.0",
                 "external-editor": "2.2.0",
@@ -8607,14 +8377,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "cli-cursor": {
@@ -8641,6 +8411,12 @@
                     "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
                     "dev": true
                 },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
                 "onetime": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
@@ -8660,6 +8436,16 @@
                         "signal-exit": "3.0.2"
                     }
                 },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
+                    }
+                },
                 "strip-ansi": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -8670,9 +8456,9 @@
                     }
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -8758,9 +8544,9 @@
             }
         },
         "is-alphabetical": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.1.tgz",
-            "integrity": "sha1-x3B5zJHU76x3W+EDS/LSQ/lebwg=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.2.tgz",
+            "integrity": "sha512-V0xN4BYezDHcBSKb1QHUFMlR4as/XEuCZBzMJUU4n7+Cbt33SmUnSol+pnXFvLxSHNq2CemUXNdaXV6Flg7+xg==",
             "dev": true
         },
         "is-alphanumeric": {
@@ -8770,13 +8556,13 @@
             "dev": true
         },
         "is-alphanumerical": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.1.tgz",
-            "integrity": "sha1-37SqTRCF4zvbYcLe6cgOnGwZ9Ts=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz",
+            "integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
             "dev": true,
             "requires": {
-                "is-alphabetical": "1.0.1",
-                "is-decimal": "1.0.1"
+                "is-alphabetical": "1.0.2",
+                "is-decimal": "1.0.2"
             }
         },
         "is-arrayish": {
@@ -8840,9 +8626,9 @@
             "dev": true
         },
         "is-decimal": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.1.tgz",
-            "integrity": "sha1-9ftqlJlq2ejjdh+/vQkfH8qMToI=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.2.tgz",
+            "integrity": "sha512-TRzl7mOCchnhchN+f3ICUCzYvL9ul7R+TYOsZ8xia++knyZAJfv/uA1FvQXsAnYIl1T3B2X5E/J7Wb1QXiIBXg==",
             "dev": true
         },
         "is-descriptor": {
@@ -8931,9 +8717,9 @@
             }
         },
         "is-hexadecimal": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.1.tgz",
-            "integrity": "sha1-bghLvJIGH7sJcexYts5tQE4k2mk=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz",
+            "integrity": "sha512-but/G3sapV3MNyqiDBLrOi4x8uCIw0RY3o/Vb5GT0sMFHrVV7731wFSVy41T5FO1og7G0gXLJh0MkgPRouko/A==",
             "dev": true
         },
         "is-installed-globally": {
@@ -9160,9 +8946,9 @@
             "dev": true
         },
         "is-whitespace-character": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.1.tgz",
-            "integrity": "sha1-muAXbzKCtlRXoZks2whPil+DPjs=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz",
+            "integrity": "sha512-SzM+T5GKUCtLhlHFKt2SDAX2RFzfS6joT91F2/WSi9LxgFdsnhfPK/UIA+JhRR2xuyLdrCys2PiFDrtn1fU5hQ==",
             "dev": true
         },
         "is-windows": {
@@ -9417,14 +9203,14 @@
                     "dev": true
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "cliui": {
@@ -9468,6 +9254,12 @@
                     "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
                     "dev": true
                 },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
                 "is-glob": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
@@ -9484,7 +9276,7 @@
                     "dev": true,
                     "requires": {
                         "ansi-escapes": "3.1.0",
-                        "chalk": "2.3.2",
+                        "chalk": "2.4.0",
                         "exit": "0.1.2",
                         "glob": "7.1.2",
                         "graceful-fs": "4.1.11",
@@ -9540,6 +9332,16 @@
                         "regex-cache": "0.4.4"
                     }
                 },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
+                    }
+                },
                 "strip-ansi": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -9550,9 +9352,9 @@
                     }
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -9604,7 +9406,7 @@
             "integrity": "sha512-KSg3EOToCgkX+lIvenKY7J8s426h6ahXxaUFJxvGoEk0562Z6inWj1TnKoGycTASwiLD+6kSYFALcjdosq9KIQ==",
             "dev": true,
             "requires": {
-                "chalk": "2.3.2",
+                "chalk": "2.4.0",
                 "glob": "7.1.2",
                 "jest-environment-jsdom": "22.4.3",
                 "jest-environment-node": "22.4.3",
@@ -9627,14 +9429,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "has-flag": {
@@ -9644,9 +9446,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -9660,7 +9462,7 @@
             "integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
             "dev": true,
             "requires": {
-                "chalk": "2.3.2",
+                "chalk": "2.4.0",
                 "diff": "3.5.0",
                 "jest-get-type": "22.4.3",
                 "pretty-format": "22.4.3"
@@ -9676,14 +9478,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "diff": {
@@ -9699,9 +9501,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -9726,7 +9528,7 @@
             "requires": {
                 "jest-mock": "22.4.3",
                 "jest-util": "22.4.3",
-                "jsdom": "11.7.0"
+                "jsdom": "11.8.0"
             }
         },
         "jest-environment-node": {
@@ -9848,7 +9650,7 @@
             "integrity": "sha512-yZCPCJUcEY6R5KJB/VReo1AYI2b+5Ky+C+JA1v34jndJsRcLpU4IZX4rFJn7yDTtdNbO/nNqg+3SDIPNH2ecnw==",
             "dev": true,
             "requires": {
-                "chalk": "2.3.2",
+                "chalk": "2.4.0",
                 "co": "4.6.0",
                 "expect": "22.4.3",
                 "graceful-fs": "4.1.11",
@@ -9871,14 +9673,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "has-flag": {
@@ -9903,9 +9705,9 @@
                     }
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -9928,7 +9730,7 @@
             "integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
             "dev": true,
             "requires": {
-                "chalk": "2.3.2",
+                "chalk": "2.4.0",
                 "jest-get-type": "22.4.3",
                 "pretty-format": "22.4.3"
             },
@@ -9943,14 +9745,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "has-flag": {
@@ -9960,9 +9762,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -9977,7 +9779,7 @@
             "dev": true,
             "requires": {
                 "@babel/code-frame": "7.0.0-beta.44",
-                "chalk": "2.3.2",
+                "chalk": "2.4.0",
                 "micromatch": "2.3.11",
                 "slash": "1.0.0",
                 "stack-utils": "1.0.1"
@@ -10019,14 +9821,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "expand-brackets": {
@@ -10090,9 +9892,9 @@
                     }
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -10119,7 +9921,7 @@
             "dev": true,
             "requires": {
                 "browser-resolve": "1.11.2",
-                "chalk": "2.3.2"
+                "chalk": "2.4.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -10132,14 +9934,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "has-flag": {
@@ -10149,9 +9951,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -10196,7 +9998,7 @@
                 "babel-core": "6.26.0",
                 "babel-jest": "22.4.3",
                 "babel-plugin-istanbul": "4.1.6",
-                "chalk": "2.3.2",
+                "chalk": "2.4.0",
                 "convert-source-map": "1.5.1",
                 "exit": "0.1.2",
                 "graceful-fs": "4.1.11",
@@ -10263,14 +10065,14 @@
                     "dev": true
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "cliui": {
@@ -10314,6 +10116,12 @@
                     "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
                     "dev": true
                 },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
                 "is-glob": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
@@ -10344,6 +10152,16 @@
                         "regex-cache": "0.4.4"
                     }
                 },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
+                    }
+                },
                 "strip-ansi": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -10354,9 +10172,9 @@
                     }
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -10405,7 +10223,7 @@
             "integrity": "sha512-JXA0gVs5YL0HtLDCGa9YxcmmV2LZbwJ+0MfyXBBc5qpgkEYITQFJP7XNhcHFbUvRiniRpRbGVfJrOoYhhGE0RQ==",
             "dev": true,
             "requires": {
-                "chalk": "2.3.2",
+                "chalk": "2.4.0",
                 "jest-diff": "22.4.3",
                 "jest-matcher-utils": "22.4.3",
                 "mkdirp": "0.5.1",
@@ -10423,14 +10241,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "has-flag": {
@@ -10440,9 +10258,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -10457,7 +10275,7 @@
             "dev": true,
             "requires": {
                 "callsites": "2.0.0",
-                "chalk": "2.3.2",
+                "chalk": "2.4.0",
                 "graceful-fs": "4.1.11",
                 "is-ci": "1.0.10",
                 "jest-message-util": "22.4.3",
@@ -10481,14 +10299,14 @@
                     "dev": true
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "has-flag": {
@@ -10504,9 +10322,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -10520,7 +10338,7 @@
             "integrity": "sha512-CfFM18W3GSP/xgmA4UouIx0ljdtfD2mjeBC6c89Gg17E44D4tQhAcTrZmf9djvipwU30kSTnk6CzcxdCCeSXfA==",
             "dev": true,
             "requires": {
-                "chalk": "2.3.2",
+                "chalk": "2.4.0",
                 "jest-config": "22.4.3",
                 "jest-get-type": "22.4.3",
                 "leven": "2.1.0",
@@ -10537,14 +10355,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "has-flag": {
@@ -10554,9 +10372,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -10613,7 +10431,7 @@
                 "babel-register": "6.26.0",
                 "babylon": "7.0.0-beta.44",
                 "colors": "1.1.2",
-                "flow-parser": "0.69.0",
+                "flow-parser": "0.70.0",
                 "lodash": "4.17.5",
                 "micromatch": "2.3.11",
                 "neo-async": "2.5.1",
@@ -10724,9 +10542,9 @@
             }
         },
         "jsdom": {
-            "version": "11.7.0",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.7.0.tgz",
-            "integrity": "sha512-9NzSc4Iz4gN9p4uoPbBUzro21QdgL32swaWIaWS8eEVQ2I69fRJAy/MKyvlEIk0V7HtKgfMbbOKyTZUrzR2Hsw==",
+            "version": "11.8.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.8.0.tgz",
+            "integrity": "sha512-fZZSH6P8tVqYIQl0WKpZuQljPu2cW41Uj/c9omtyGwjwZCB8c82UAi7BSQs/F1FgWovmZsoU02z3k28eHp0Cdw==",
             "dev": true,
             "requires": {
                 "abab": "1.0.4",
@@ -11157,7 +10975,7 @@
             "dev": true,
             "requires": {
                 "app-root-path": "2.0.1",
-                "chalk": "2.3.2",
+                "chalk": "2.4.0",
                 "commander": "2.15.1",
                 "cosmiconfig": "4.0.0",
                 "debug": "3.1.0",
@@ -11189,14 +11007,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "execa": {
@@ -11240,7 +11058,7 @@
                         "log-update": "1.0.2",
                         "ora": "0.2.3",
                         "p-map": "1.2.0",
-                        "rxjs": "5.5.9",
+                        "rxjs": "5.5.10",
                         "stream-to-observable": "0.2.0",
                         "strip-ansi": "3.0.1"
                     },
@@ -11345,7 +11163,7 @@
                     "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.3.2"
+                        "chalk": "2.4.0"
                     }
                 },
                 "stream-to-observable": {
@@ -11358,9 +11176,9 @@
                     }
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -11387,7 +11205,7 @@
                 "log-update": "1.0.2",
                 "ora": "0.2.3",
                 "p-map": "1.2.0",
-                "rxjs": "5.5.9",
+                "rxjs": "5.5.10",
                 "stream-to-observable": "0.1.0",
                 "strip-ansi": "3.0.1"
             }
@@ -11622,6 +11440,14 @@
             "requires": {
                 "pseudomap": "1.0.2",
                 "yallist": "2.1.2"
+            },
+            "dependencies": {
+                "yallist": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+                    "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+                    "dev": true
+                }
             }
         },
         "macaddress": {
@@ -11676,15 +11502,15 @@
             }
         },
         "markdown-escapes": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.1.tgz",
-            "integrity": "sha1-GZTfLTr0gR3lmmcUk0wrIpJzRRg=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.2.tgz",
+            "integrity": "sha512-lbRZ2mE3Q9RtLjxZBZ9+IMl68DKIXaVAhwvwn9pmjnPLS0h/6kyBMgNhqi1xFJ/2yv6cSyv0jbiZavZv93JkkA==",
             "dev": true
         },
         "markdown-table": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.1.tgz",
-            "integrity": "sha1-Sz3ToTPRUYuO8NvHCb8qG0gkvIw=",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.2.tgz",
+            "integrity": "sha512-NcWuJFHDA8V3wkDgR/j4+gZx+YQwstPgfQDV8ndUeWWzta3dnDTBxpVzqS9lkmJAuV5YX35lmyojl6HO5JXAgw==",
             "dev": true
         },
         "math-expression-evaluator": {
@@ -11737,12 +11563,12 @@
             "integrity": "sha1-8IeETSVcdUDzaQbaMLoQbA7l7i8=",
             "dev": true,
             "requires": {
-                "collapse-white-space": "1.0.3",
+                "collapse-white-space": "1.0.4",
                 "detab": "2.0.1",
                 "mdast-util-definitions": "1.2.2",
                 "mdurl": "1.0.1",
                 "trim": "0.0.1",
-                "trim-lines": "1.1.0",
+                "trim-lines": "1.1.1",
                 "unist-builder": "1.0.2",
                 "unist-util-generated": "1.1.1",
                 "unist-util-position": "3.0.0",
@@ -11832,7 +11658,7 @@
             "requires": {
                 "commondir": "1.0.1",
                 "deep-extend": "0.4.2",
-                "ejs": "2.5.8",
+                "ejs": "2.5.9",
                 "glob": "7.1.2",
                 "globby": "6.1.0",
                 "mkdirp": "0.5.1",
@@ -12139,6 +11965,26 @@
             "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
             "dev": true
         },
+        "minipass": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
+            "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.1.1",
+                "yallist": "3.0.2"
+            }
+        },
+        "minizlib": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+            "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "minipass": "2.2.4"
+            }
+        },
         "mississippi": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
@@ -12202,7 +12048,7 @@
                 "inherits": "2.0.3",
                 "parents": "1.0.1",
                 "readable-stream": "2.3.6",
-                "resolve": "1.7.0",
+                "resolve": "1.7.1",
                 "stream-combiner2": "1.1.1",
                 "subarg": "1.0.0",
                 "through2": "2.0.3",
@@ -12351,6 +12197,30 @@
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
             "dev": true
         },
+        "needle": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
+            "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "debug": "2.6.9",
+                "iconv-lite": "0.4.21",
+                "sax": "1.2.4"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
         "negotiator": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
@@ -12435,7 +12305,7 @@
                 "stream-browserify": "2.0.1",
                 "stream-http": "2.8.1",
                 "string_decoder": "1.1.1",
-                "timers-browserify": "2.0.6",
+                "timers-browserify": "2.0.10",
                 "tty-browserify": "0.0.0",
                 "url": "0.11.0",
                 "util": "0.10.3",
@@ -12452,6 +12322,25 @@
                 "semver": "5.5.0",
                 "shellwords": "0.1.1",
                 "which": "1.3.0"
+            }
+        },
+        "node-pre-gyp": {
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.9.1.tgz",
+            "integrity": "sha1-8RwHUW3ZL4cZnbx+GDjqt81WyeA=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "detect-libc": "1.0.3",
+                "mkdirp": "0.5.1",
+                "needle": "2.2.0",
+                "nopt": "4.0.1",
+                "npm-packlist": "1.1.10",
+                "npmlog": "4.1.2",
+                "rc": "1.2.6",
+                "rimraf": "2.6.2",
+                "semver": "5.5.0",
+                "tar": "4.4.1"
             }
         },
         "nomnom": {
@@ -12487,6 +12376,17 @@
                     "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
                     "dev": true
                 }
+            }
+        },
+        "nopt": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+            "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "abbrev": "1.1.1",
+                "osenv": "0.1.5"
             }
         },
         "normalize-package-data": {
@@ -12528,6 +12428,24 @@
                 "sort-keys": "1.1.2"
             }
         },
+        "npm-bundled": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
+            "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
+            "dev": true,
+            "optional": true
+        },
+        "npm-packlist": {
+            "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
+            "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "ignore-walk": "3.0.1",
+                "npm-bundled": "1.0.3"
+            }
+        },
         "npm-path": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.4.tgz",
@@ -12544,7 +12462,7 @@
             "dev": true,
             "requires": {
                 "ansi-styles": "3.2.1",
-                "chalk": "2.3.2",
+                "chalk": "2.4.0",
                 "cross-spawn": "5.1.0",
                 "memory-streams": "0.1.3",
                 "minimatch": "3.0.4",
@@ -12564,14 +12482,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "has-flag": {
@@ -12581,9 +12499,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -12609,6 +12527,19 @@
                 "commander": "2.15.1",
                 "npm-path": "2.0.4",
                 "which": "1.3.0"
+            }
+        },
+        "npmlog": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+            "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "are-we-there-yet": "1.1.4",
+                "console-control-strings": "1.1.0",
+                "gauge": "2.7.4",
+                "set-blocking": "2.0.0"
             }
         },
         "nth-check": {
@@ -12870,6 +12801,17 @@
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
             "dev": true
         },
+        "osenv": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+            "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
+            }
+        },
         "output-file-sync": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
@@ -13004,7 +12946,7 @@
                 "browserify-aes": "1.2.0",
                 "create-hash": "1.2.0",
                 "evp_bytestokey": "1.0.3",
-                "pbkdf2": "3.0.14"
+                "pbkdf2": "3.0.16"
             }
         },
         "parse-entities": {
@@ -13013,12 +12955,12 @@
             "integrity": "sha1-gRLYhHExnyerrk1klksSL+ThuJA=",
             "dev": true,
             "requires": {
-                "character-entities": "1.2.1",
-                "character-entities-legacy": "1.1.1",
-                "character-reference-invalid": "1.1.1",
-                "is-alphanumerical": "1.0.1",
-                "is-decimal": "1.0.1",
-                "is-hexadecimal": "1.0.1"
+                "character-entities": "1.2.2",
+                "character-entities-legacy": "1.1.2",
+                "character-reference-invalid": "1.1.2",
+                "is-alphanumerical": "1.0.2",
+                "is-decimal": "1.0.2",
+                "is-hexadecimal": "1.0.2"
             }
         },
         "parse-filepath": {
@@ -13209,14 +13151,14 @@
             }
         },
         "pbkdf2": {
-            "version": "3.0.14",
-            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
-            "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
+            "version": "3.0.16",
+            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
+            "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
             "dev": true,
             "requires": {
                 "create-hash": "1.2.0",
                 "create-hmac": "1.1.7",
-                "ripemd160": "2.0.1",
+                "ripemd160": "2.0.2",
                 "safe-buffer": "5.1.1",
                 "sha.js": "2.4.11"
             }
@@ -13462,7 +13404,7 @@
                 "caniuse-api": "1.6.1",
                 "postcss": "5.2.18",
                 "postcss-selector-parser": "2.2.3",
-                "vendors": "1.0.1"
+                "vendors": "1.0.2"
             },
             "dependencies": {
                 "browserslist": {
@@ -13471,7 +13413,7 @@
                     "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
                     "dev": true,
                     "requires": {
-                        "caniuse-db": "1.0.30000827",
+                        "caniuse-db": "1.0.30000830",
                         "electron-to-chromium": "1.3.42"
                     }
                 }
@@ -13547,14 +13489,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "has-flag": {
@@ -13569,9 +13511,9 @@
                     "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.3.2",
+                        "chalk": "2.4.0",
                         "source-map": "0.6.1",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "source-map": {
@@ -13581,9 +13523,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -13611,14 +13553,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "has-flag": {
@@ -13633,9 +13575,9 @@
                     "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.3.2",
+                        "chalk": "2.4.0",
                         "source-map": "0.6.1",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "source-map": {
@@ -13645,9 +13587,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -13675,14 +13617,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "has-flag": {
@@ -13697,9 +13639,9 @@
                     "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.3.2",
+                        "chalk": "2.4.0",
                         "source-map": "0.6.1",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "source-map": {
@@ -13709,9 +13651,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -13739,14 +13681,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "has-flag": {
@@ -13761,9 +13703,9 @@
                     "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.3.2",
+                        "chalk": "2.4.0",
                         "source-map": "0.6.1",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "source-map": {
@@ -13773,9 +13715,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -14203,6 +14145,28 @@
                 }
             }
         },
+        "rc": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
+            "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "deep-extend": "0.4.2",
+                "ini": "1.3.5",
+                "minimist": "1.2.0",
+                "strip-json-comments": "2.0.1"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
         "react": {
             "version": "15.6.1",
             "resolved": "https://registry.npmjs.org/react/-/react-15.6.1.tgz",
@@ -14376,7 +14340,7 @@
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
             "dev": true,
             "requires": {
-                "resolve": "1.7.0"
+                "resolve": "1.7.1"
             }
         },
         "redent": {
@@ -14553,15 +14517,15 @@
             "integrity": "sha512-XZgICP2gJ1MHU7+vQaRM+VA9HEL3X253uwUM/BGgx3iv6TH2B3bF3B8q00DKcyP9YrJV+/7WOWEWBFF/u8cIsw==",
             "dev": true,
             "requires": {
-                "collapse-white-space": "1.0.3",
-                "is-alphabetical": "1.0.1",
-                "is-decimal": "1.0.1",
-                "is-whitespace-character": "1.0.1",
+                "collapse-white-space": "1.0.4",
+                "is-alphabetical": "1.0.2",
+                "is-decimal": "1.0.2",
+                "is-whitespace-character": "1.0.2",
                 "is-word-character": "1.0.1",
-                "markdown-escapes": "1.0.1",
+                "markdown-escapes": "1.0.2",
                 "parse-entities": "1.1.1",
                 "repeat-string": "1.6.1",
-                "state-toggle": "1.0.0",
+                "state-toggle": "1.0.1",
                 "trim": "0.0.1",
                 "trim-trailing-lines": "1.1.0",
                 "unherit": "1.1.0",
@@ -14587,17 +14551,17 @@
             "integrity": "sha512-xLuyKTnuQer3ke9hkU38SUYLiTmS078QOnoFavztmbt/pAJtNSkNtFgR0U//uCcmG0qnyxao+PDuatQav46F1w==",
             "dev": true,
             "requires": {
-                "ccount": "1.0.2",
+                "ccount": "1.0.3",
                 "is-alphanumeric": "1.0.0",
-                "is-decimal": "1.0.1",
-                "is-whitespace-character": "1.0.1",
+                "is-decimal": "1.0.2",
+                "is-whitespace-character": "1.0.2",
                 "longest-streak": "2.0.2",
-                "markdown-escapes": "1.0.1",
-                "markdown-table": "1.1.1",
+                "markdown-escapes": "1.0.2",
+                "markdown-table": "1.1.2",
                 "mdast-util-compact": "1.0.1",
                 "parse-entities": "1.1.1",
                 "repeat-string": "1.6.1",
-                "state-toggle": "1.0.0",
+                "state-toggle": "1.0.1",
                 "stringify-entities": "1.3.1",
                 "unherit": "1.1.0",
                 "xtend": "4.0.1"
@@ -14770,9 +14734,9 @@
             "dev": true
         },
         "resolve": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.0.tgz",
-            "integrity": "sha512-QdgZ5bjR1WAlpLaO5yHepFvC+o3rCr6wpfE2tpJNMkXdulf2jKomQBdNRQITF3ZKHNlT71syG98yQP03gasgnA==",
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+            "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
             "dev": true,
             "requires": {
                 "path-parse": "1.0.5"
@@ -14861,24 +14825,13 @@
             }
         },
         "ripemd160": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
-            "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+            "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
             "dev": true,
             "requires": {
-                "hash-base": "2.0.2",
+                "hash-base": "3.0.4",
                 "inherits": "2.0.3"
-            },
-            "dependencies": {
-                "hash-base": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
-                    "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
-                    "dev": true,
-                    "requires": {
-                        "inherits": "2.0.3"
-                    }
-                }
             }
         },
         "run-async": {
@@ -14920,9 +14873,9 @@
             }
         },
         "rxjs": {
-            "version": "5.5.9",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.9.tgz",
-            "integrity": "sha512-DHG9AHmCmgaFWgjBcXp6NxFDmh3MvIA62GqTWmLnTzr/3oZ6h5hLD8NA+9j+GF0jEwklNIpI4KuuyLG8UWMEvQ==",
+            "version": "5.5.10",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.10.tgz",
+            "integrity": "sha512-SRjimIDUHJkon+2hFo7xnvNC4ZEHGzCRwh9P7nzX3zPkCGFEg/tuElrNR7L/rZMagnK2JeH2jQwPRpmyXyLB6A==",
             "dev": true,
             "requires": {
                 "symbol-observable": "1.0.1"
@@ -14963,7 +14916,7 @@
                 "anymatch": "2.0.0",
                 "exec-sh": "0.2.1",
                 "fb-watchman": "2.0.0",
-                "fsevents": "1.1.3",
+                "fsevents": "1.2.0",
                 "micromatch": "3.1.10",
                 "minimist": "1.2.0",
                 "walker": "1.0.7",
@@ -15059,9 +15012,9 @@
             }
         },
         "serialize-javascript": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.4.0.tgz",
-            "integrity": "sha1-fJWFFNtqwkQ6irwGLcn3iGp/YAU=",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.5.0.tgz",
+            "integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ==",
             "dev": true
         },
         "serve-index": {
@@ -15367,7 +15320,7 @@
                 "faye-websocket": "0.11.1",
                 "inherits": "2.0.3",
                 "json3": "3.3.2",
-                "url-parse": "1.3.0"
+                "url-parse": "1.4.0"
             },
             "dependencies": {
                 "debug": {
@@ -15440,9 +15393,9 @@
             "dev": true
         },
         "space-separated-tokens": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.1.tgz",
-            "integrity": "sha1-lpW5355lrsGBHUw/nOUlILwvfk0=",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.2.tgz",
+            "integrity": "sha512-G3jprCEw+xFEs0ORweLmblJ3XLymGGr6hxZYTYZjIlvDti9vOBUjRQa1Rzjt012aRrocKstHwdNi+F7HguPsEA==",
             "dev": true,
             "requires": {
                 "trim": "0.0.1"
@@ -15601,9 +15554,9 @@
             "dev": true
         },
         "state-toggle": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.0.tgz",
-            "integrity": "sha1-0g+aYWu08MO5i5GSLSW2QKorxCU=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.1.tgz",
+            "integrity": "sha512-Qe8QntFrrpWTnHwvwj2FZTgv+PKIsp0B9VxLzLLbSpPXWOgRgc5LVj/aTiSfK1RqIeF9jeC1UeOH8Q8y60A7og==",
             "dev": true
         },
         "static-extend": {
@@ -15781,36 +15734,14 @@
             "dev": true
         },
         "string-width": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
             "dev": true,
             "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                    "dev": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "3.0.0"
-                    }
-                }
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
             }
         },
         "string.prototype.padend": {
@@ -15839,10 +15770,10 @@
             "integrity": "sha1-sVDsLXKsTBtfMktR+2soyc3/BYw=",
             "dev": true,
             "requires": {
-                "character-entities-html4": "1.1.1",
-                "character-entities-legacy": "1.1.1",
-                "is-alphanumerical": "1.0.1",
-                "is-hexadecimal": "1.0.1"
+                "character-entities-html4": "1.1.2",
+                "character-entities-legacy": "1.1.2",
+                "is-alphanumerical": "1.0.2",
+                "is-hexadecimal": "1.0.2"
             }
         },
         "stringify-object": {
@@ -15984,12 +15915,18 @@
             "requires": {
                 "ajv": "5.5.2",
                 "ajv-keywords": "2.1.1",
-                "chalk": "2.3.2",
+                "chalk": "2.4.0",
                 "lodash": "4.17.5",
                 "slice-ansi": "1.0.0",
                 "string-width": "2.1.1"
             },
             "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
                 "ansi-styles": {
                     "version": "3.2.1",
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -16000,14 +15937,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "has-flag": {
@@ -16031,10 +15968,29 @@
                         "is-fullwidth-code-point": "2.0.0"
                     }
                 },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "3.0.0"
+                    }
+                },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -16047,6 +16003,22 @@
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
             "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
             "dev": true
+        },
+        "tar": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
+            "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "chownr": "1.0.1",
+                "fs-minipass": "1.2.5",
+                "minipass": "2.2.4",
+                "minizlib": "1.1.0",
+                "mkdirp": "0.5.1",
+                "safe-buffer": "5.1.1",
+                "yallist": "3.0.2"
+            }
         },
         "temp": {
             "version": "0.8.3",
@@ -16223,9 +16195,9 @@
             "dev": true
         },
         "timers-browserify": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.6.tgz",
-            "integrity": "sha512-HQ3nbYRAowdVd0ckGFvmJPPCOH/CHleFN/Y0YQCX1DVaB7t+KFvisuyN09fuP8Jtp1CpfSh8O8bMkHbdbPe6Pw==",
+            "version": "2.0.10",
+            "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
+            "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
             "dev": true,
             "requires": {
                 "setimmediate": "1.0.5"
@@ -16362,9 +16334,9 @@
             "dev": true
         },
         "trim-lines": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.0.tgz",
-            "integrity": "sha1-mSbQPt4Tuhj31CIiYx+wTHn/Jv4=",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.1.tgz",
+            "integrity": "sha512-X+eloHbgJGxczUk1WSjIvn7aC9oN3jVE3rQfRVKcgpavi3jxtCn0VVKtjOBj64Yop96UYn/ujJRpTbCdAF1vyg==",
             "dev": true
         },
         "trim-newlines": {
@@ -16386,9 +16358,9 @@
             "dev": true
         },
         "trough": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.1.tgz",
-            "integrity": "sha1-qf2LA5Swro//guBjOgo2zK1bX4Y=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.2.tgz",
+            "integrity": "sha512-FHkoUZvG6Egrv9XZAyYGKEyb1JMsFphgPjoczkZC2y6W93U1jswcVURB8MUvtsahEPEVACyxD47JAL63vF4JsQ==",
             "dev": true
         },
         "tty-browserify": {
@@ -16514,10 +16486,10 @@
             "integrity": "sha512-pW2f82bCIo2ifuIGYcV12fL96kMMYgw7JKVEgh7ODlrM9rj6vXSY3BV+H6lCcv1ksxynFf582hwWLnA1qRFy4w==",
             "dev": true,
             "requires": {
-                "bail": "1.0.2",
+                "bail": "1.0.3",
                 "extend": "3.0.1",
                 "is-plain-obj": "1.1.0",
-                "trough": "1.0.1",
+                "trough": "1.0.2",
                 "vfile": "2.3.0",
                 "x-is-function": "1.0.4",
                 "x-is-string": "0.1.0"
@@ -16651,7 +16623,7 @@
             "integrity": "sha1-ZtfmpEnm9nIguXarPLi166w55R0=",
             "dev": true,
             "requires": {
-                "array-iterate": "1.1.1"
+                "array-iterate": "1.1.2"
             }
         },
         "unist-util-position": {
@@ -16802,19 +16774,19 @@
             "dev": true
         },
         "url-parse": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.3.0.tgz",
-            "integrity": "sha512-zPvPA3T7P6M+0iNsgX+iAcAz4GshKrowtQBHHc/28tVsBc8jK7VRCNX+2GEcoE6zDB6XqXhcyiUWPVZY6C70Cg==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.0.tgz",
+            "integrity": "sha512-ERuGxDiQ6Xw/agN4tuoCRbmwRuZP0cJ1lJxJubXr5Q/5cDa78+Dc4wfvtxzhzhkm5VvmW6Mf8EVj9SPGN4l8Lg==",
             "dev": true,
             "requires": {
-                "querystringify": "1.0.0",
+                "querystringify": "2.0.0",
                 "requires-port": "1.0.0"
             },
             "dependencies": {
                 "querystringify": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
-                    "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs=",
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
+                    "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw==",
                     "dev": true
                 }
             }
@@ -16954,9 +16926,9 @@
             "dev": true
         },
         "vendors": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz",
-            "integrity": "sha1-N61zyO5Bf7PVgOeFMSMH0nSEfyI=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.2.tgz",
+            "integrity": "sha512-w/hry/368nO21AN9QljsaIhb9ZiZtZARoVH5f3CsFbawdLdayCgKRPup7CggujvySMxx0I91NOyxdVENohprLQ==",
             "dev": true
         },
         "verror": {
@@ -17018,17 +16990,6 @@
                 "vfile-statistics": "1.1.0"
             },
             "dependencies": {
-                "string-width": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                    "dev": true,
-                    "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
-                    }
-                },
                 "supports-color": {
                     "version": "4.5.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
@@ -17287,7 +17248,7 @@
                 "acorn-dynamic-import": "3.0.0",
                 "ajv": "6.4.0",
                 "ajv-keywords": "3.1.0",
-                "chrome-trace-event": "0.1.2",
+                "chrome-trace-event": "0.1.3",
                 "enhanced-resolve": "4.0.0",
                 "eslint-scope": "3.7.1",
                 "loader-runner": "2.3.0",
@@ -17299,7 +17260,7 @@
                 "node-libs-browser": "2.1.0",
                 "schema-utils": "0.4.5",
                 "tapable": "1.0.0",
-                "uglifyjs-webpack-plugin": "1.2.4",
+                "uglifyjs-webpack-plugin": "1.2.5",
                 "watchpack": "1.5.0",
                 "webpack-sources": "1.1.0"
             },
@@ -17381,15 +17342,15 @@
                     }
                 },
                 "uglifyjs-webpack-plugin": {
-                    "version": "1.2.4",
-                    "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.4.tgz",
-                    "integrity": "sha512-z0IbjpW8b3O/OVn+TTZN4pI29RN1zktFBXLIzzfZ+++cUtZ1ERSlLWgpE/5OERuEUs1ijVQnpYAkSlpoVmQmSQ==",
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.5.tgz",
+                    "integrity": "sha512-hIQJ1yxAPhEA2yW/i7Fr+SXZVMp+VEI3d42RTHBgQd2yhp/1UdBcR3QEWPV5ahBxlqQDMEMTuTEvDHSFINfwSw==",
                     "dev": true,
                     "requires": {
                         "cacache": "10.0.4",
                         "find-cache-dir": "1.0.0",
                         "schema-utils": "0.4.5",
-                        "serialize-javascript": "1.4.0",
+                        "serialize-javascript": "1.5.0",
                         "source-map": "0.6.1",
                         "uglify-es": "3.3.9",
                         "webpack-sources": "1.1.0",
@@ -17503,7 +17464,7 @@
                         "babel-register": "6.26.0",
                         "babylon": "6.18.0",
                         "colors": "1.1.2",
-                        "flow-parser": "0.69.0",
+                        "flow-parser": "0.70.0",
                         "lodash": "4.17.5",
                         "micromatch": "2.3.11",
                         "node-dir": "0.1.8",
@@ -17572,7 +17533,7 @@
             "integrity": "sha512-kMi6NquWwUhmQok2IFrtAEIbaVvujzYvtDGb5WElkwylbLboDsCgizv8IjSi/Q6SQRJ8Crayl1JCBnIJ3rU4Rg==",
             "dev": true,
             "requires": {
-                "chalk": "2.3.2",
+                "chalk": "2.4.0",
                 "cross-spawn": "6.0.5",
                 "diff": "3.5.0",
                 "enhanced-resolve": "4.0.0",
@@ -17591,12 +17552,12 @@
                 "p-lazy": "1.0.0",
                 "prettier": "1.11.1",
                 "resolve-cwd": "2.0.0",
-                "supports-color": "5.3.0",
+                "supports-color": "5.4.0",
                 "v8-compile-cache": "1.1.2",
                 "webpack-addons": "1.1.5",
                 "yargs": "11.0.0",
                 "yeoman-environment": "2.0.6",
-                "yeoman-generator": "2.0.3"
+                "yeoman-generator": "2.0.4"
             },
             "dependencies": {
                 "ansi-escapes": {
@@ -17627,14 +17588,14 @@
                     "dev": true
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "cli-cursor": {
@@ -17709,7 +17670,7 @@
                     "dev": true,
                     "requires": {
                         "ansi-escapes": "3.1.0",
-                        "chalk": "2.3.2",
+                        "chalk": "2.4.0",
                         "cli-cursor": "2.1.0",
                         "cli-width": "2.2.0",
                         "external-editor": "2.2.0",
@@ -17717,11 +17678,17 @@
                         "lodash": "4.17.5",
                         "mute-stream": "0.0.7",
                         "run-async": "2.3.0",
-                        "rxjs": "5.5.9",
+                        "rxjs": "5.5.10",
                         "string-width": "2.1.1",
                         "strip-ansi": "4.0.0",
                         "through": "2.3.8"
                     }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
                 },
                 "listr": {
                     "version": "0.13.0",
@@ -17743,7 +17710,7 @@
                         "log-update": "1.0.2",
                         "ora": "0.2.3",
                         "p-map": "1.2.0",
-                        "rxjs": "5.5.9",
+                        "rxjs": "5.5.10",
                         "stream-to-observable": "0.2.0",
                         "strip-ansi": "3.0.1"
                     },
@@ -17898,7 +17865,7 @@
                     "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.3.2"
+                        "chalk": "2.4.0"
                     }
                 },
                 "onetime": {
@@ -17929,6 +17896,16 @@
                         "any-observable": "0.2.0"
                     }
                 },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
+                    }
+                },
                 "strip-ansi": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -17939,9 +17916,9 @@
                     }
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -17985,9 +17962,9 @@
             }
         },
         "webpack-dev-middleware": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.0.1.tgz",
-            "integrity": "sha512-JCturcEZNGA0KHEpOJVRTC/VVazTcPfpR9c1Au6NO9a+jxCRchMi87Qe7y3JeOzc0v5eMMKpuGBnPdN52NA+CQ==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.1.2.tgz",
+            "integrity": "sha512-Z11Zp3GTvCe6mGbbtma+lMB9xRfJcNtupXfmvFBujyXqLNms6onDnSi9f/Cb2rw6KkD5kgibOfxhN7npZwTiGA==",
             "dev": true,
             "requires": {
                 "loud-rejection": "1.6.0",
@@ -18014,9 +17991,9 @@
             }
         },
         "webpack-dev-server": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.1.tgz",
-            "integrity": "sha512-u5lz6REb3+KklgSIytUIOrmWgnpgFmfj/+I+GBXurhEoCsHXpG9twk4NO3bsu72GC9YtxIsiavjfRdhmNt0A/A==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.3.tgz",
+            "integrity": "sha512-UXfgQIPpdw2rByoUnCrMAIXCS7IJJMp5N0MDQNk9CuQvirCkuWlu7gQpCS8Kaiz4kogC4TdAQHG3jzh/DdqEWg==",
             "dev": true,
             "requires": {
                 "ansi-html": "0.0.7",
@@ -18029,7 +18006,7 @@
                 "del": "3.0.0",
                 "express": "4.16.3",
                 "html-entities": "1.2.1",
-                "http-proxy-middleware": "0.17.4",
+                "http-proxy-middleware": "0.18.0",
                 "import-local": "1.0.0",
                 "internal-ip": "1.2.0",
                 "ip": "1.1.5",
@@ -18043,12 +18020,18 @@
                 "sockjs-client": "1.1.4",
                 "spdy": "3.4.7",
                 "strip-ansi": "3.0.1",
-                "supports-color": "5.3.0",
-                "webpack-dev-middleware": "3.0.1",
+                "supports-color": "5.4.0",
+                "webpack-dev-middleware": "3.1.2",
                 "webpack-log": "1.2.0",
-                "yargs": "9.0.1"
+                "yargs": "11.0.0"
             },
             "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
                 "camelcase": {
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
@@ -18056,25 +18039,23 @@
                     "dev": true
                 },
                 "cliui": {
-                    "version": "3.2.0",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-                    "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
+                    "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
                     "dev": true,
                     "requires": {
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
+                        "string-width": "2.1.1",
+                        "strip-ansi": "4.0.0",
                         "wrap-ansi": "2.1.0"
                     },
                     "dependencies": {
-                        "string-width": {
-                            "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                             "dev": true,
                             "requires": {
-                                "code-point-at": "1.1.0",
-                                "is-fullwidth-code-point": "1.0.0",
-                                "strip-ansi": "3.0.1"
+                                "ansi-regex": "3.0.0"
                             }
                         }
                     }
@@ -18120,34 +18101,69 @@
                     "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
                     "dev": true
                 },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
+                    },
+                    "dependencies": {
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "3.0.0"
+                            }
+                        }
+                    }
+                },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
                     }
                 },
                 "yargs": {
-                    "version": "9.0.1",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
-                    "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
+                    "version": "11.0.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
+                    "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
                     "dev": true,
                     "requires": {
-                        "camelcase": "4.1.0",
-                        "cliui": "3.2.0",
+                        "cliui": "4.0.0",
                         "decamelize": "1.2.0",
+                        "find-up": "2.1.0",
                         "get-caller-file": "1.0.2",
                         "os-locale": "2.1.0",
-                        "read-pkg-up": "2.0.0",
                         "require-directory": "2.1.1",
                         "require-main-filename": "1.0.1",
                         "set-blocking": "2.0.0",
                         "string-width": "2.1.1",
                         "which-module": "2.0.0",
                         "y18n": "3.2.1",
-                        "yargs-parser": "7.0.0"
+                        "yargs-parser": "9.0.2"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "9.0.2",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+                    "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "4.1.0"
                     }
                 }
             }
@@ -18158,7 +18174,7 @@
             "integrity": "sha512-U9AnICnu50HXtiqiDxuli5gLB5PGBo7VvcHx36jRZHwK4vzOYLbImqT4lwWwoMHdQWwEKw736fCHEekokTEKHA==",
             "dev": true,
             "requires": {
-                "chalk": "2.3.2",
+                "chalk": "2.4.0",
                 "log-symbols": "2.2.0",
                 "loglevelnext": "1.0.4",
                 "uuid": "3.2.1"
@@ -18174,14 +18190,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "has-flag": {
@@ -18196,13 +18212,13 @@
                     "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.3.2"
+                        "chalk": "2.4.0"
                     }
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -18359,6 +18375,16 @@
             "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
             "dev": true
         },
+        "wide-align": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+            "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "string-width": "1.0.2"
+            }
+        },
         "window-size": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
@@ -18388,19 +18414,6 @@
             "requires": {
                 "string-width": "1.0.2",
                 "strip-ansi": "3.0.1"
-            },
-            "dependencies": {
-                "string-width": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                    "dev": true,
-                    "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
-                    }
-                }
             }
         },
         "wrappy": {
@@ -18475,9 +18488,9 @@
             "dev": true
         },
         "yallist": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+            "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
             "dev": true
         },
         "yargs": {
@@ -18501,6 +18514,12 @@
                 "yargs-parser": "7.0.0"
             },
             "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
                 "camelcase": {
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
@@ -18527,6 +18546,33 @@
                                 "code-point-at": "1.1.0",
                                 "is-fullwidth-code-point": "1.0.0",
                                 "strip-ansi": "3.0.1"
+                            }
+                        }
+                    }
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
+                    },
+                    "dependencies": {
+                        "is-fullwidth-code-point": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                            "dev": true
+                        },
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "3.0.0"
                             }
                         }
                     }
@@ -18566,7 +18612,7 @@
             "integrity": "sha512-jzHBTTy8EPI4ImV8dpUMt+Q5zELkSU5xvGpndHcHudQ4tqN6YgIWaCGmRFl+HDchwRUkcgyjQ+n6/w5zlJBCPg==",
             "dev": true,
             "requires": {
-                "chalk": "2.3.2",
+                "chalk": "2.4.0",
                 "debug": "3.1.0",
                 "diff": "3.5.0",
                 "escape-string-regexp": "1.0.5",
@@ -18591,14 +18637,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "diff": {
@@ -18632,7 +18678,7 @@
                     "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.3.2"
+                        "chalk": "2.4.0"
                     }
                 },
                 "pify": {
@@ -18642,9 +18688,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -18653,13 +18699,13 @@
             }
         },
         "yeoman-generator": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-2.0.3.tgz",
-            "integrity": "sha512-mODmrZ26a94djmGZZuIiomSGlN4wULdou29ZwcySupb2e9FdvoCl7Ps2FqHFjEHio3kOl/iBeaNqrnx3C3NwWg==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-2.0.4.tgz",
+            "integrity": "sha512-Sgvz3MAkOpEIobcpW3rjEl6bOTNnl8SkibP9z7hYKfIGIlw0QDC2k0MAeXvyE2pLqc2M0Duql+6R7/W9GrJojg==",
             "dev": true,
             "requires": {
                 "async": "2.6.0",
-                "chalk": "2.3.2",
+                "chalk": "2.4.0",
                 "cli-table": "0.3.1",
                 "cross-spawn": "5.1.0",
                 "dargs": "5.1.0",
@@ -18695,14 +18741,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "has-flag": {
@@ -18781,9 +18827,9 @@
                     }
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "scripts": {
         "check": "npm run docs:lint && npm run lint && npm run test && npm run functional",
-        "dev": "node_modules/.bin/webpack-dev-server -d --content-base sandbox --inline --hot --port 3002",
+        "dev": "webpack-dev-server -d --content-base sandbox --inline --hot --port 3002",
         "dist:rd3g": "rm -rf dist/ && webpack --config webpack.config.dist.js -p --display-modules --optimize-minimize",
         "dist:sandbox": "webpack --config webpack.config.js -p",
         "dist:transpile": "./node_modules/babel-cli/bin/babel.js -d lib src",
@@ -75,7 +75,7 @@
         "style-loader": "0.18.2",
         "webpack": "4.2.0",
         "webpack-cli": "2.0.12",
-        "webpack-dev-server": "3.1.1",
+        "webpack-dev-server": "3.1.3",
         "webpack-visualizer-plugin": "0.1.11"
     },
     "engines": {

--- a/sandbox/Sandbox.jsx
+++ b/sandbox/Sandbox.jsx
@@ -10,7 +10,7 @@ import defaultConfig from '../src/components/graph/graph.config';
 import { Graph } from '../src';
 import data from './data';
 import Utils from './utils';
-import ReactD3GraphUtils from  '../src/utils';
+import ReactD3GraphUtils from '../src/utils';
 import { JsonTree } from 'react-editable-json-tree';
 
 /**
@@ -21,7 +21,10 @@ export default class Sandbox extends React.Component {
     constructor(props) {
         super(props);
 
-        const schemaProps = Utils.generateFormSchema(defaultConfig, '', {});
+        // NOTE: Override initial configs here. e.g: { staticGraph: true }
+        const configOverride = {};
+
+        const schemaProps = Utils.generateFormSchema(Object.assign(defaultConfig, configOverride), '', {});
 
         const schema = {
             type: 'object',
@@ -29,14 +32,14 @@ export default class Sandbox extends React.Component {
         };
 
         const uiSchema = {
-            height: {'ui:readonly': 'true'},
-            width: {'ui:readonly': 'true'}
+            height: { 'ui:readonly': 'true' },
+            width: { 'ui:readonly': 'true' }
         };
 
         this.uiSchema = uiSchema;
 
         this.state = {
-            config: {}, // NOTE: Override initial configs here. e.g: {staticGraph: true}
+            config: {},
             generatedConfig: {},
             schema,
             data,
@@ -44,15 +47,15 @@ export default class Sandbox extends React.Component {
         };
     }
 
-    onClickNode = (id) => window.alert(`Clicked node ${id}`);
+    onClickNode = id => window.alert(`Clicked node ${id}`);
 
     onClickLink = (source, target) => window.alert(`Clicked link between ${source} and ${target}`);
 
-    onMouseOverNode = (id) => console.info(`Do something when mouse is over node (${id})`);
+    onMouseOverNode = id => console.info(`Do something when mouse is over node (${id})`);
 
-    onMouseOutNode = (id) => console.info(`Do something when mouse is out of node (${id})`);
+    onMouseOutNode = id => console.info(`Do something when mouse is out of node (${id})`);
 
-    onMouseOverLink = (source, target) => 
+    onMouseOverLink = (source, target) =>
         console.info(`Do something when mouse is over link between ${source} and ${target}`);
 
     onMouseOutLink = (source, target) =>
@@ -65,7 +68,7 @@ export default class Sandbox extends React.Component {
         const fullscreen = !this.state.fullscreen;
 
         this.setState({ fullscreen });
-    }
+    };
 
     /**
      * Play stopped animations.
@@ -94,7 +97,7 @@ export default class Sandbox extends React.Component {
             let nLinks = Math.floor(Math.random() * (5 - minIndex + 1) + minIndex);
             const newNode = `Node ${this.state.data.nodes.length}`;
 
-            this.state.data.nodes.push({id: newNode});
+            this.state.data.nodes.push({ id: newNode });
 
             while (this.state.data.nodes[i] && this.state.data.nodes[i].id && nLinks) {
                 this.state.data.links.push({
@@ -112,15 +115,13 @@ export default class Sandbox extends React.Component {
         } else {
             // 1st node
             const data = {
-                nodes: [
-                    {id: 'Node 1'}
-                ],
+                nodes: [{ id: 'Node 1' }],
                 links: []
             };
 
             this.setState({ data });
         }
-    }
+    };
 
     /**
      * Remove a node.
@@ -137,9 +138,9 @@ export default class Sandbox extends React.Component {
         } else {
             window.alert('No more nodes to remove!');
         }
-    }
+    };
 
-    _buildGraphConfig = (data) => {
+    _buildGraphConfig = data => {
         let config = {};
         let schemaPropsValues = {};
 
@@ -151,32 +152,32 @@ export default class Sandbox extends React.Component {
             schemaPropsValues[k]['default'] = data.formData[k];
         }
 
-        return {config, schemaPropsValues};
-    }
+        return { config, schemaPropsValues };
+    };
 
-    refreshGraph = (data) => {
-        const {config, schemaPropsValues} = this._buildGraphConfig(data);
+    refreshGraph = data => {
+        const { config, schemaPropsValues } = this._buildGraphConfig(data);
 
         this.state.schema.properties = ReactD3GraphUtils.merge(this.state.schema.properties, schemaPropsValues);
 
         this.setState({
             config
         });
-    }
+    };
 
     /**
      * Generate graph configuration file ready to use!
      */
-    onSubmit = (data) => {
+    onSubmit = data => {
         const { config } = this._buildGraphConfig(data);
 
         this.setState({ generatedConfig: config });
-    }
+    };
 
     onClickSubmit = () => {
         // Hack for allow submit button to live outside jsonform
         document.body.querySelector('.invisible-button').click();
-    }
+    };
 
     resetGraphConfig = () => {
         const generatedConfig = {};
@@ -193,7 +194,7 @@ export default class Sandbox extends React.Component {
             generatedConfig,
             schema
         });
-    }
+    };
 
     /**
      * This function decorates nodes and links with positions. The motivation
@@ -202,21 +203,21 @@ export default class Sandbox extends React.Component {
      * @param  {Object} nodes nodes and links with minimalist structure.
      * @return {Object} the graph where now nodes containing (x,y) coords.
      */
-    decorateGraphNodesWithInitialPositioning = (nodes) => {
-        return nodes.map(n => (
+    decorateGraphNodesWithInitialPositioning = nodes => {
+        return nodes.map(n =>
             Object.assign({}, n, {
                 x: n.x || Math.floor(Math.random() * 500),
                 y: n.y || Math.floor(Math.random() * 500)
             })
-        ));
-    }
+        );
+    };
 
     /**
      * Update graph data each time an update is triggered
      * by JsonTree
      * @param {Object} data update graph data (nodes and links)
      */
-    onGraphDataUpdate = (data) => this.setState({ data });
+    onGraphDataUpdate = data => this.setState({ data });
 
     /**
      * Build common piece of the interface that contains some interactions such as
@@ -227,25 +228,55 @@ export default class Sandbox extends React.Component {
             cursor: this.state.config.staticGraph ? 'not-allowed' : 'pointer'
         };
 
-        const fullscreen = this.state.fullscreen ?
-            (<span className='cross-icon' onClick={this.onToggleFullScreen}>❌</span>)
-            : (<button onClick={this.onToggleFullScreen}
-                className='btn btn-default btn-margin-left'>Fullscreen</button>);
+        const fullscreen = this.state.fullscreen ? (
+            <span className="cross-icon" onClick={this.onToggleFullScreen}>
+                ❌
+            </span>
+        ) : (
+            <button onClick={this.onToggleFullScreen} className="btn btn-default btn-margin-left">
+                Fullscreen
+            </button>
+        );
 
         return (
             <div>
                 {fullscreen}
-                <button onClick={this.restartGraphSimulation} className='btn btn-default btn-margin-left' style={btnStyle} disabled={this.state.config.staticGraph}>▶️</button>
-                <button onClick={this.pauseGraphSimulation} className='btn btn-default btn-margin-left' style={btnStyle} disabled={this.state.config.staticGraph}>⏸️</button>
-                <button onClick={this.resetNodesPositions} className='btn btn-default btn-margin-left' style={btnStyle} disabled={this.state.config.staticGraph}>Unstick nodes</button>
-                <button onClick={this.onClickAddNode} className='btn btn-default btn-margin-left'>+</button>
-                <button onClick={this.onClickRemoveNode} className='btn btn-default btn-margin-left'>-</button>
-                <span className='container__graph-info'>
+                <button
+                    onClick={this.restartGraphSimulation}
+                    className="btn btn-default btn-margin-left"
+                    style={btnStyle}
+                    disabled={this.state.config.staticGraph}
+                >
+                    ▶️
+                </button>
+                <button
+                    onClick={this.pauseGraphSimulation}
+                    className="btn btn-default btn-margin-left"
+                    style={btnStyle}
+                    disabled={this.state.config.staticGraph}
+                >
+                    ⏸️
+                </button>
+                <button
+                    onClick={this.resetNodesPositions}
+                    className="btn btn-default btn-margin-left"
+                    style={btnStyle}
+                    disabled={this.state.config.staticGraph}
+                >
+                    Unstick nodes
+                </button>
+                <button onClick={this.onClickAddNode} className="btn btn-default btn-margin-left">
+                    +
+                </button>
+                <button onClick={this.onClickRemoveNode} className="btn btn-default btn-margin-left">
+                    -
+                </button>
+                <span className="container__graph-info">
                     <b>Nodes: </b> {this.state.data.nodes.length} | <b>Links: </b> {this.state.data.links.length}
                 </span>
             </div>
         );
-    }
+    };
 
     render() {
         // This does not happens in this sandbox scenario running time, but if we set staticGraph config
@@ -270,51 +301,63 @@ export default class Sandbox extends React.Component {
         if (this.state.fullscreen) {
             graphProps.config = Object.assign({}, graphProps.config, {
                 height: window.innerHeight,
-                width: window.innerWidth,
+                width: window.innerWidth
             });
 
             return (
                 <div>
                     {this.buildCommonInteractionsPanel()}
-                    <Graph ref='graph' {...graphProps}/>
+                    <Graph ref="graph" {...graphProps} />
                 </div>
             );
         } else {
             // @TODO: Only show configs that differ from default ones in "Your config" box
             return (
-                <div className='container'>
-                    <div className='container__graph'>
+                <div className="container">
+                    <div className="container__graph">
                         {this.buildCommonInteractionsPanel()}
-                        <div className='container__graph-area'>
-                            <Graph ref='graph' {...graphProps}/>
+                        <div className="container__graph-area">
+                            <Graph ref="graph" {...graphProps} />
                         </div>
                     </div>
-                    <div className='container__form'>
+                    <div className="container__form">
                         <h4>
-                            <a href="https://github.com/danielcaldas/react-d3-graph" target="_blank">react-d3-graph</a>
+                            <a href="https://github.com/danielcaldas/react-d3-graph" target="_blank">
+                                react-d3-graph
+                            </a>
                         </h4>
                         <h4>
-                            <a href="https://danielcaldas.github.io/react-d3-graph/docs/index.html" target="_blank">docs</a>
+                            <a href="https://danielcaldas.github.io/react-d3-graph/docs/index.html" target="_blank">
+                                docs
+                            </a>
                         </h4>
                         <h3>Configurations</h3>
-                        <Form className='form-wrapper'
+                        <Form
+                            className="form-wrapper"
                             schema={this.state.schema}
                             uiSchema={this.uiSchema}
                             onChange={this.refreshGraph}
-                            onSubmit={this.onSubmit}>
-                            <button className='invisible-button' type='submit'></button>
+                            onSubmit={this.onSubmit}
+                        >
+                            <button className="invisible-button" type="submit" />
                         </Form>
-                        <button className='submit-button btn btn-primary' onClick={this.onClickSubmit}>Generate config</button>
-                        <button className='reset-button btn btn-danger' onClick={this.resetGraphConfig}>Reset config</button>
+                        <button className="submit-button btn btn-primary" onClick={this.onClickSubmit}>
+                            Generate config
+                        </button>
+                        <button className="reset-button btn btn-danger" onClick={this.resetGraphConfig}>
+                            Reset config
+                        </button>
                     </div>
-                    <div className='container__graph-config'>
+                    <div className="container__graph-config">
                         <h4>Your config</h4>
                         <JSONContainer data={this.state.generatedConfig} staticData={false} />
                     </div>
-                    <div className='container__graph-data'>
-                        <h4>Graph Data <small>(editable)</small></h4>
-                        <div className='json-data-container'>
-                            <JsonTree data={this.state.data} onFullyUpdate={this.onGraphDataUpdate}/>
+                    <div className="container__graph-data">
+                        <h4>
+                            Graph Data <small>(editable)</small>
+                        </h4>
+                        <div className="json-data-container">
+                            <JsonTree data={this.state.data} onFullyUpdate={this.onGraphDataUpdate} />
                         </div>
                     </div>
                 </div>
@@ -329,8 +372,6 @@ class JSONContainer extends React.Component {
     }
 
     render() {
-        return (
-            <pre className='json-data-container'>{JSON.stringify(this.props.data, null, 2)}</pre>
-        );
+        return <pre className="json-data-container">{JSON.stringify(this.props.data, null, 2)}</pre>;
     }
 }

--- a/src/components/graph/Graph.jsx
+++ b/src/components/graph/Graph.jsx
@@ -2,11 +2,7 @@ import React from 'react';
 
 import { drag as d3Drag } from 'd3-drag';
 import { forceLink as d3ForceLink } from 'd3-force';
-import {
-    select as d3Select,
-    selectAll as d3SelectAll,
-    event as d3Event
-} from 'd3-selection';
+import { select as d3Select, selectAll as d3SelectAll, event as d3Event } from 'd3-selection';
 import { zoom as d3Zoom } from 'd3-zoom';
 
 import CONST from './graph.const';
@@ -104,27 +100,30 @@ export default class Graph extends React.Component {
         this.state.simulation.nodes(this.state.d3Nodes).on('tick', this._tick);
 
         const forceLink = d3ForceLink(this.state.d3Links)
-                            .id(l => l.id)
-                            .distance(D3_CONST.LINK_IDEAL_DISTANCE)
-                            .strength(D3_CONST.FORCE_LINK_STRENGTH);
+            .id(l => l.id)
+            .distance(D3_CONST.LINK_IDEAL_DISTANCE)
+            .strength(D3_CONST.FORCE_LINK_STRENGTH);
 
         this.state.simulation.force(CONST.LINK_CLASS_NAME, forceLink);
 
         const customNodeDrag = d3Drag()
-                                .on('start', this._onDragStart)
-                                .on('drag', this._onDragMove)
-                                .on('end', this._onDragEnd);
+            .on('start', this._onDragStart)
+            .on('drag', this._onDragMove)
+            .on('end', this._onDragEnd);
 
-        d3Select(`#${this.state.id}-${CONST.GRAPH_WRAPPER_ID}`).selectAll('.node').call(customNodeDrag);
+        d3Select(`#${this.state.id}-${CONST.GRAPH_WRAPPER_ID}`)
+            .selectAll('.node')
+            .call(customNodeDrag);
     }
 
     /**
      * Handles d3 drag 'end' event.
      * @returns {undefined}
      */
-    _onDragEnd = () => !this.state.config.staticGraph
-                        && this.state.config.automaticRearrangeAfterDropNode
-                        && this.state.simulation.alphaTarget(D3_CONST.SIMULATION_ALPHA_TARGET).restart();
+    _onDragEnd = () =>
+        !this.state.config.staticGraph &&
+        this.state.config.automaticRearrangeAfterDropNode &&
+        this.state.simulation.alphaTarget(D3_CONST.SIMULATION_ALPHA_TARGET).restart();
 
     /**
      * Handles d3 'drag' event.
@@ -151,7 +150,7 @@ export default class Graph extends React.Component {
 
             this._tick();
         }
-    }
+    };
 
     /**
      * Handles d3 drag 'start' event.
@@ -165,19 +164,10 @@ export default class Graph extends React.Component {
      * @param  {boolean} [value=false] - the highlight value to be set (true or false).
      * @returns {undefined}
      */
-    _setNodeHighlightedValue = (id, value=false) => {
-        this.state.highlightedNode = value ? id : '';
-        this.state.nodes[id].highlighted = value;
-
-        // when highlightDegree is 0 we want only to highlight selected node
-        if (this.state.links[id] && this.state.config.highlightDegree !== 0) {
-            Object.keys(this.state.links[id]).forEach(k => {
-                this.state.nodes[k].highlighted = value;
-            });
-        }
-
-        this._tick();
-    }
+    _setNodeHighlightedValue = (id, value = false) =>
+        this._tick(
+            graphHelper.updateNodeHighlightedValue(this.state.nodes, this.state.links, this.state.config, id, value)
+        );
 
     /**
      * The tick function simply calls React set state in order to update component and render nodes
@@ -185,16 +175,19 @@ export default class Graph extends React.Component {
      * @param {Object} state - new state to pass on.
      * @returns {undefined}
      */
-    _tick = (state={}) => this.setState(state);
+    _tick = (state = {}) => this.setState(state);
 
     /**
      * Configures zoom upon graph with default or user provided values.<br/>
      * {@link https://github.com/d3/d3-zoom#zoom}
      * @returns {undefined}
      */
-    _zoomConfig = () => d3Select(`#${this.state.id}-${CONST.GRAPH_WRAPPER_ID}`)
-                            .call(d3Zoom().scaleExtent([this.state.config.minZoom, this.state.config.maxZoom])
-                            .on('zoom', this._zoomed));
+    _zoomConfig = () =>
+        d3Select(`#${this.state.id}-${CONST.GRAPH_WRAPPER_ID}`).call(
+            d3Zoom()
+                .scaleExtent([this.state.config.minZoom, this.state.config.maxZoom])
+                .on('zoom', this._zoomed)
+        );
 
     /**
      * Handler for 'zoom' event within zoom config.
@@ -206,29 +199,29 @@ export default class Graph extends React.Component {
         d3SelectAll(`#${this.state.id}-${CONST.GRAPH_CONTAINER_ID}`).attr('transform', transform);
 
         this.state.config.panAndZoom && this.setState({ transform: transform.k });
-    }
+    };
 
     /**
      * Handles mouse over node event.
      * @param  {string} id - id of the node that participates in the event.
      * @returns {undefined}
      */
-    onMouseOverNode = (id) => {
+    onMouseOverNode = id => {
         this.props.onMouseOverNode && this.props.onMouseOverNode(id);
 
         this.state.config.nodeHighlightBehavior && this._setNodeHighlightedValue(id, true);
-    }
+    };
 
     /**
      * Handles mouse out node event.
      * @param  {string} id - id of the node that participates in the event.
      * @returns {undefined}
      */
-    onMouseOutNode = (id) => {
+    onMouseOutNode = id => {
         this.props.onMouseOutNode && this.props.onMouseOutNode(id);
 
         this.state.config.nodeHighlightBehavior && this._setNodeHighlightedValue(id, false);
-    }
+    };
 
     /**
      * Handles mouse over link event.
@@ -244,7 +237,7 @@ export default class Graph extends React.Component {
 
             this._tick();
         }
-    }
+    };
 
     /**
      * Handles mouse out link event.
@@ -260,13 +253,13 @@ export default class Graph extends React.Component {
 
             this._tick();
         }
-    }
+    };
 
     /**
-    * Calls d3 simulation.stop().<br/>
-    * {@link https://github.com/d3/d3-force#simulation_stop}
-    * @returns {undefined}
-    */
+     * Calls d3 simulation.stop().<br/>
+     * {@link https://github.com/d3/d3-force#simulation_stop}
+     * @returns {undefined}
+     */
     pauseSimulation = () => this.state.simulation.stop();
 
     /**
@@ -290,7 +283,7 @@ export default class Graph extends React.Component {
 
             this._tick();
         }
-    }
+    };
 
     /**
      * Calls d3 simulation.restart().<br/>
@@ -310,14 +303,15 @@ export default class Graph extends React.Component {
     }
 
     componentWillReceiveProps(nextProps) {
-        const newGraphElements = nextProps.data.nodes.length !== this.state.nodesInputSnapshot.length
-                                || nextProps.data.links.length !== this.state.linksInputSnapshot.length
-                                || !utils.isDeepEqual(nextProps.data, {
-                                    nodes: this.state.nodesInputSnapshot,
-                                    links: this.state.linksInputSnapshot,
-                                });
-        const configUpdated = !utils.isObjectEmpty(nextProps.config)
-                            && !utils.isDeepEqual(nextProps.config, this.state.config);
+        const newGraphElements =
+            nextProps.data.nodes.length !== this.state.nodesInputSnapshot.length ||
+            nextProps.data.links.length !== this.state.linksInputSnapshot.length ||
+            !utils.isDeepEqual(nextProps.data, {
+                nodes: this.state.nodesInputSnapshot,
+                links: this.state.linksInputSnapshot
+            });
+        const configUpdated =
+            !utils.isObjectEmpty(nextProps.config) && !utils.isDeepEqual(nextProps.config, this.state.config);
         const state = newGraphElements ? graphHelper.initializeGraphState(nextProps, this.state) : this.state;
         const config = configUpdated ? utils.merge(DEFAULT_CONFIG, nextProps.config || {}) : this.state.config;
 

--- a/src/components/graph/graph.config.js
+++ b/src/components/graph/graph.config.js
@@ -55,7 +55,7 @@
  * @param {string} [node.color='#d3d3d3'] - 🔍🔍🔍 this is the color that will be applied to the node if no **color property**
  * is found inside the node itself (yes **you can pass a property 'color' inside the node and that color will override the
  * this default one**).
- * @param {string} [node.fontColor='black'] - fill color for node's <text> svg label
+ * @param {string} [node.fontColor='black'] - 🔍🔍🔍 fill color for node's <text> svg label.
  * @param {number} [node.fontSize=10] - {@link https://developer.mozilla.org/en-US/docs/Web/CSS/font-size?v=control|font-size}
  * property for all nodes' labels.
  * @param {string} [node.fontWeight='normal'] - {@link https://developer.mozilla.org/en/docs/Web/CSS/font-weight?v=control|font-weight}

--- a/src/components/graph/graph.helper.js
+++ b/src/components/graph/graph.helper.js
@@ -12,9 +12,11 @@
 /**
  * @typedef {Object} Node
  * @property {string} id - the id of the node.
- * @property {string} [color] - color of the node (optional).
- * @property {string} [size] - size of the node (optional).
- * @property {string} [symbolType] - symbol type of the node (optional).
+ * @property {string} [color=] - color of the node (optional).
+ * @property {string} [fontColor=] - node text label font color (optional).
+ * @property {string} [size=] - size of the node (optional).
+ * @property {string} [symbolType=] - symbol type of the node (optional).
+ * @property {string} [svg=] - custom svg for node (optional).
  * @memberof Graph/helper
  */
 import {

--- a/src/components/graph/graph.helper.js
+++ b/src/components/graph/graph.helper.js
@@ -383,4 +383,34 @@ function initializeGraphState({ data, id, config }, state) {
     };
 }
 
-export { buildLinkProps, buildNodeProps, initializeGraphState };
+/**
+ * This function updates the highlighted value for a given node and also updates highlight props.
+ * @param {Object.<string, Object>} nodes - an object containing all nodes mapped by their id.
+ * @param {Object.<string, Object>} links - an object containing a matrix of connections of the graph.
+ * @param {Object} config - an object containing rd3g consumer defined configurations {@link #config config} for the graph.
+ * @param {string} id - identifier of node to update.
+ * @param {string} value - new highlight value for given node.
+ * @returns {Object} returns an object containing the updated nodes
+ * and the id of the highlighted node.
+ */
+function updateNodeHighlightedValue(nodes, links, config, id, value = false) {
+    const highlightedNode = value ? id : '';
+    const node = Object.assign({}, nodes[id], { highlighted: value });
+    let updatedNodes = Object.assign({}, nodes, { [id]: node });
+
+    // when highlightDegree is 0 we want only to highlight selected node
+    if (links[id] && config.highlightDegree !== 0) {
+        updatedNodes = Object.keys(links[id]).reduce((acc, linkId) => {
+            const updatedNode = Object.assign({}, updatedNodes[linkId], { highlighted: value });
+
+            return Object.assign(acc, { [linkId]: updatedNode });
+        }, updatedNodes);
+    }
+
+    return {
+        nodes: updatedNodes,
+        highlightedNode
+    };
+}
+
+export { buildLinkProps, buildNodeProps, initializeGraphState, updateNodeHighlightedValue };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@7.0.0-beta.44", "@babel/code-frame@^7.0.0-beta.35", "@babel/code-frame@^7.0.0-beta.40":
+"@babel/code-frame@7.0.0-beta.44", "@babel/code-frame@^7.0.0-beta.35":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz#2a02643368de80916162be70865c97774f3adbd9"
   dependencies:
@@ -55,7 +55,7 @@
     babylon "7.0.0-beta.44"
     lodash "^4.2.0"
 
-"@babel/traverse@^7.0.0-beta.40":
+"@babel/traverse@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.44.tgz#a970a2c45477ad18017e2e465a0606feee0d2966"
   dependencies:
@@ -70,7 +70,7 @@
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-"@babel/types@7.0.0-beta.44", "@babel/types@^7.0.0-beta.40":
+"@babel/types@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.44.tgz#6b1b164591f77dec0a0342aca995f2d046b3a757"
   dependencies:
@@ -126,8 +126,8 @@
     "@types/jquery" "*"
 
 "@types/chai@*":
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.1.2.tgz#f1af664769cfb50af805431c407425ed619daa21"
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.1.3.tgz#b8a74352977a23b604c01aa784f5b793443fb7dc"
 
 "@types/chai@4.0.8":
   version "4.0.8"
@@ -404,8 +404,8 @@ array-includes@^3.0.3:
     es-abstract "^1.7.0"
 
 array-iterate@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/array-iterate/-/array-iterate-1.1.1.tgz#865bf7f8af39d6b0982c60902914ac76bc0108f6"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/array-iterate/-/array-iterate-1.1.2.tgz#f66a57e84426f8097f4197fbb6c051b8e5cdf7d8"
 
 array-map@~0.0.0:
   version "0.0.0"
@@ -596,13 +596,13 @@ babel-core@6.26.0, babel-core@^6.0.0, babel-core@^6.0.14, babel-core@^6.17.0, ba
     source-map "^0.5.6"
 
 babel-eslint@^8.0.2:
-  version "8.2.2"
-  resolved "http://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.2.tgz#1102273354c6f0b29b4ea28a65f97d122296b68b"
+  version "8.2.3"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-8.2.3.tgz#1a2e6681cc9bc4473c32899e59915e19cd6733cf"
   dependencies:
-    "@babel/code-frame" "^7.0.0-beta.40"
-    "@babel/traverse" "^7.0.0-beta.40"
-    "@babel/types" "^7.0.0-beta.40"
-    babylon "^7.0.0-beta.40"
+    "@babel/code-frame" "7.0.0-beta.44"
+    "@babel/traverse" "7.0.0-beta.44"
+    "@babel/types" "7.0.0-beta.44"
+    babylon "7.0.0-beta.44"
     eslint-scope "~3.7.1"
     eslint-visitor-keys "^1.0.0"
 
@@ -1355,7 +1355,7 @@ babelify@^7.3.0:
     babel-core "^6.0.14"
     object-assign "^4.0.0"
 
-babylon@7.0.0-beta.44, babylon@^7.0.0-beta.30, babylon@^7.0.0-beta.40:
+babylon@7.0.0-beta.44, babylon@^7.0.0-beta.30:
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.44.tgz#89159e15e6e30c5096e22d738d8c0af8a0e8ca1d"
 
@@ -1364,8 +1364,8 @@ babylon@^6.17.2, babylon@^6.17.3, babylon@^6.18.0:
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
 bail@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.2.tgz#f7d6c1731630a9f9f0d4d35ed1f962e2074a1764"
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.3.tgz#63cfb9ddbac829b02a3128cd53224be78e6c21a3"
 
 balanced-match@^0.4.2:
   version "0.4.2"
@@ -1380,8 +1380,8 @@ base62@^1.1.0:
   resolved "https://registry.yarnpkg.com/base62/-/base62-1.2.8.tgz#1264cb0fb848d875792877479dbe8bae6bae3428"
 
 base64-js@^1.0.2:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.3.tgz#fb13668233d9614cf5fb4bce95a9ba4096cdf801"
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
 
 base@^0.11.1:
   version "0.11.2"
@@ -1416,12 +1416,6 @@ binary-extensions@^1.0.0:
 binaryextensions@2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-2.1.1.tgz#3209a51ca4a4ad541a3b8d3d6a6d5b83a2485935"
-
-block-stream@*:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
-  dependencies:
-    inherits "~2.0.0"
 
 bluebird@3.5.0:
   version "3.5.0"
@@ -1636,7 +1630,7 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-builtin-modules@^1.0.0, builtin-modules@^1.1.1:
+builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
@@ -1750,20 +1744,20 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000827"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000827.tgz#bd2839dd196093b44c28c17f93513140c9d92588"
+  version "1.0.30000830"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000830.tgz#6e45255b345649fd15ff59072da1e12bb3de2f13"
 
 caniuse-lite@^1.0.30000792:
-  version "1.0.30000827"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000827.tgz#2dad2354e4810c3c9bb1cfc57f655c270c25fa52"
+  version "1.0.30000830"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000830.tgz#cb96b8a2dd3cbfe04acea2af3c4e894249095328"
 
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
 ccount@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.2.tgz#53b6a2f815bb77b9c2871f7b9a72c3a25f1d8e89"
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.3.tgz#f1cec43f332e2ea5a569fd46f9f5bde4e6102aff"
 
 center-align@^0.1.1:
   version "0.1.3"
@@ -1791,8 +1785,8 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     supports-color "^2.0.0"
 
 chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.0.tgz#a060a297a6b57e15b61ca63ce84995daa0fe6e52"
   dependencies:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
@@ -1807,20 +1801,20 @@ chalk@~0.4.0:
     strip-ansi "~0.1.0"
 
 character-entities-html4@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/character-entities-html4/-/character-entities-html4-1.1.1.tgz#359a2a4a0f7e29d3dc2ac99bdbe21ee39438ea50"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/character-entities-html4/-/character-entities-html4-1.1.2.tgz#c44fdde3ce66b52e8d321d6c1bf46101f0150610"
 
 character-entities-legacy@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.1.tgz#f40779df1a101872bb510a3d295e1fccf147202f"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.2.tgz#7c6defb81648498222c9855309953d05f4d63a9c"
 
 character-entities@^1.0.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-1.2.1.tgz#f76871be5ef66ddb7f8f8e3478ecc374c27d6dca"
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-1.2.2.tgz#58c8f371c0774ef0ba9b2aca5f00d8f100e6e363"
 
 character-reference-invalid@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.1.tgz#942835f750e4ec61a308e60c2ef8cc1011202efc"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz#21e421ad3d84055952dab4a43a04e73cd425d3ed"
 
 chardet@^0.4.0:
   version "0.4.2"
@@ -1868,8 +1862,8 @@ chownr@^1.0.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
 
 chrome-trace-event@^0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-0.1.2.tgz#90f36885d5345a50621332f0717b595883d5d982"
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-0.1.3.tgz#d395af2d31c87b90a716c831fe326f69768ec084"
 
 ci-info@^1.0.0:
   version "1.1.3"
@@ -2013,8 +2007,8 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
 collapse-white-space@^1.0.0, collapse-white-space@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.3.tgz#4b906f670e5a963a87b76b0e1689643341b6023c"
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.4.tgz#ce05cf49e54c3277ae573036a26851ba430a0091"
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -2074,8 +2068,8 @@ combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
     delayed-stream "~1.0.0"
 
 comma-separated-tokens@^1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.4.tgz#72083e58d4a462f01866f6617f4d98a3cd3b8a46"
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.5.tgz#b13793131d9ea2d2431cf5b507ddec258f0ce0db"
   dependencies:
     trim "0.0.1"
 
@@ -2524,7 +2518,11 @@ d3-collection@1, d3-collection@1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.4.tgz#342dfd12837c90974f33f1cc0a785aea570dcdc2"
 
-d3-color@1, d3-color@1.0.3:
+d3-color@1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.1.0.tgz#73957299b63ca935bf19c6c9d835e90066028329"
+
+d3-color@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.0.3.tgz#bc7643fca8e53a8347e2fbdaffa236796b58509b"
 
@@ -2795,7 +2793,7 @@ dateformat@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
 
-debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
+debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -3168,8 +3166,8 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
 ejs@^2.3.1:
-  version "2.5.8"
-  resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.8.tgz#2ab6954619f225e6193b7ac5f7c39c48fefe4380"
+  version "2.5.9"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.9.tgz#7ba254582a560d267437109a68354112475b0ce5"
 
 electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30:
   version "1.3.42"
@@ -3401,10 +3399,9 @@ eslint-plugin-babel@^4.1.2:
   resolved "https://registry.yarnpkg.com/eslint-plugin-babel/-/eslint-plugin-babel-4.1.2.tgz#79202a0e35757dd92780919b2336f1fa2fe53c1e"
 
 eslint-plugin-import@^2.8.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.10.0.tgz#fa09083d5a75288df9c6c7d09fe12255985655e7"
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.11.0.tgz#15aeea37a67499d848e8e981806d4627b5503816"
   dependencies:
-    builtin-modules "^1.1.1"
     contains-path "^0.1.0"
     debug "^2.6.8"
     doctrine "1.5.0"
@@ -3414,6 +3411,7 @@ eslint-plugin-import@^2.8.0:
     lodash "^4.17.4"
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
+    resolve "^1.6.0"
 
 eslint-plugin-jest@21.15.0:
   version "21.15.0"
@@ -3566,9 +3564,9 @@ event-stream@~3.3.0:
     stream-combiner "~0.0.4"
     through "~2.3.1"
 
-eventemitter3@1.x.x:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-1.2.0.tgz#1c86991d816ad1e504750e73874224ecf3bec508"
+eventemitter3@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.0.1.tgz#4ce66c3fc5b5a6b9f2245e359e1938f1ab10f960"
 
 events@^1.0.0:
   version "1.1.1"
@@ -3935,8 +3933,8 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
 flow-parser@^0.*:
-  version "0.69.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.69.0.tgz#378b5128d6d0b554a8b2f16a4ca3e1ab9649f00e"
+  version "0.70.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.70.0.tgz#9c310187efe4380ba9a251284e9b83b95c49e857"
 
 flush-write-stream@^1.0.0:
   version "1.0.3"
@@ -3944,6 +3942,12 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
+
+follow-redirects@^1.0.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.4.1.tgz#d8120f4518190f55aac65bb6fc7b85fcd666d6aa"
+  dependencies:
+    debug "^3.1.0"
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
@@ -4012,6 +4016,12 @@ fs-extra@4.0.1:
     jsonfile "^3.0.0"
     universalify "^0.1.0"
 
+fs-minipass@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
+  dependencies:
+    minipass "^2.2.1"
+
 fs-readdir-recursive@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz#e32fc030a2ccee44a6b5371308da54be0b397d27"
@@ -4030,28 +4040,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
 fsevents@^1.0.0, fsevents@^1.1.1, fsevents@^1.1.2:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.1.3.tgz#11f82318f5fe7bb2cd22965a108e9306208216d8"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.0.tgz#e11a5ff285471e4cc43ab9cd09bb7986c565dcdc"
   dependencies:
-    nan "^2.3.0"
-    node-pre-gyp "^0.6.39"
-
-fstream-ignore@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/fstream-ignore/-/fstream-ignore-1.0.5.tgz#9c31dae34767018fe1d249b24dada67d092da105"
-  dependencies:
-    fstream "^1.0.0"
-    inherits "2"
-    minimatch "^3.0.0"
-
-fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171"
-  dependencies:
-    graceful-fs "^4.1.2"
-    inherits "~2.0.0"
-    mkdirp ">=0.5 0"
-    rimraf "2"
+    nan "^2.9.2"
+    node-pre-gyp "^0.9.0"
 
 function-bind@^1.0.2, function-bind@^1.1.1:
   version "1.1.1"
@@ -4436,12 +4429,6 @@ has@^1.0.1:
   dependencies:
     function-bind "^1.0.2"
 
-hash-base@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-2.0.2.tgz#66ea1d856db4e8a5470cadf6fce23ae5244ef2e1"
-  dependencies:
-    inherits "^2.0.1"
-
 hash-base@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-3.0.4.tgz#5fc8686847ecd73499403319a6b0a3f3f6ae4918"
@@ -4486,7 +4473,7 @@ hast-util-whitespace@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-1.0.0.tgz#bd096919625d2936e1ff17bc4df7fd727f17ece9"
 
-hawk@3.1.3, hawk@~3.1.3:
+hawk@~3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
   dependencies:
@@ -4569,8 +4556,8 @@ html-entities@^1.2.0:
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
 
 html-minifier@^3.2.3:
-  version "3.5.14"
-  resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.14.tgz#88653b24b344274e3e3d7052f1541ebea054ac60"
+  version "3.5.15"
+  resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.15.tgz#f869848d4543cbfd84f26d5514a2a87cbf9a05e0"
   dependencies:
     camel-case "3.0.x"
     clean-css "4.1.x"
@@ -4581,8 +4568,8 @@ html-minifier@^3.2.3:
     uglify-js "3.3.x"
 
 html-void-elements@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-1.0.2.tgz#9d22e0ca32acc95b3f45b8d5b4f6fbdc05affd55"
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-1.0.3.tgz#956707dbecd10cf658c92c5d27fee763aa6aa982"
 
 html-webpack-plugin@2.30.1:
   version "2.30.1"
@@ -4634,21 +4621,22 @@ http-parser-js@>=0.4.0:
   version "0.4.11"
   resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.4.11.tgz#5b720849c650903c27e521633d94696ee95f3529"
 
-http-proxy-middleware@~0.17.4:
-  version "0.17.4"
-  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz#642e8848851d66f09d4f124912846dbaeb41b833"
+http-proxy-middleware@~0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz#0987e6bb5a5606e5a69168d8f967a87f15dd8aab"
   dependencies:
     http-proxy "^1.16.2"
-    is-glob "^3.1.0"
-    lodash "^4.17.2"
-    micromatch "^2.3.11"
+    is-glob "^4.0.0"
+    lodash "^4.17.5"
+    micromatch "^3.1.9"
 
 http-proxy@^1.16.2, http-proxy@^1.8.1:
-  version "1.16.2"
-  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.16.2.tgz#06dff292952bf64dbe8471fa9df73066d4f37742"
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.17.0.tgz#7ad38494658f84605e2f6db4436df410f4e5be9a"
   dependencies:
-    eventemitter3 "1.x.x"
-    requires-port "1.x.x"
+    eventemitter3 "^3.0.0"
+    follow-redirects "^1.0.0"
+    requires-port "^1.0.0"
 
 http-server@0.11.1:
   version "0.11.1"
@@ -4691,7 +4679,7 @@ husky@0.14.3:
     normalize-path "^1.0.0"
     strip-indent "^2.0.0"
 
-iconv-lite@0.4, iconv-lite@^0.4.17, iconv-lite@^0.4.5, iconv-lite@~0.4.13:
+iconv-lite@0.4, iconv-lite@^0.4.17, iconv-lite@^0.4.4, iconv-lite@^0.4.5, iconv-lite@~0.4.13:
   version "0.4.21"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.21.tgz#c47f8733d02171189ebc4a400f3218d348094798"
   dependencies:
@@ -4718,6 +4706,12 @@ ieee754@^1.1.4:
 iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
+
+ignore-walk@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.1.tgz#a83e62e7d272ac0e3b551aaa82831a19b69f82f8"
+  dependencies:
+    minimatch "^3.0.4"
 
 ignore@^3.3.3:
   version "3.3.7"
@@ -4759,7 +4753,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -4867,16 +4861,16 @@ is-accessor-descriptor@^1.0.0:
     kind-of "^6.0.0"
 
 is-alphabetical@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.1.tgz#c77079cc91d4efac775be1034bf2d243f95e6f08"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.2.tgz#1fa6e49213cb7885b75d15862fb3f3d96c884f41"
 
 is-alphanumeric@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz#4a9cef71daf4c001c1d81d63d140cf53fd6889f4"
 
 is-alphanumerical@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.1.tgz#dfb4aa4d1085e33bdb61c2dee9c80e9c6c19f53b"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz#1138e9ae5040158dc6ff76b820acd6b7a181fd40"
   dependencies:
     is-alphabetical "^1.0.0"
     is-decimal "^1.0.0"
@@ -4934,8 +4928,8 @@ is-date-object@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
 
 is-decimal@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.1.tgz#f5fb6a94996ad9e8e3761fbfbd091f1fca8c4e82"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.2.tgz#894662d6a8709d307f3a276ca4339c8fa5dff0ff"
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -5024,8 +5018,8 @@ is-glob@^4.0.0:
     is-extglob "^2.1.1"
 
 is-hexadecimal@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.1.tgz#6e084bbc92061fbb0971ec58b6ce6d404e24da69"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz#b6e710d7d07bb66b98cb8cece5c9b4921deeb835"
 
 is-installed-globally@0.1.0:
   version "0.1.0"
@@ -5177,8 +5171,8 @@ is-valid-glob@^0.3.0:
   resolved "https://registry.yarnpkg.com/is-valid-glob/-/is-valid-glob-0.3.0.tgz#d4b55c69f51886f9b65c70d6c2622d37e29f48fe"
 
 is-whitespace-character@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.1.tgz#9ae0176f3282b65457a1992cdb084f8a5f833e3b"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz#ede53b4c6f6fb3874533751ec9280d01928d03ed"
 
 is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
@@ -5640,8 +5634,8 @@ jscodeshift@^0.5.0:
     write-file-atomic "^1.2.0"
 
 jsdom@^11.5.1:
-  version "11.7.0"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.7.0.tgz#8b45b657dae90d6d2d3a5f5d1126bb7102d0a172"
+  version "11.8.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.8.0.tgz#a52e9a7d2b931284f62c80dad5f17d7390499d8b"
   dependencies:
     abab "^1.0.4"
     acorn "^5.3.0"
@@ -6146,12 +6140,12 @@ map-visit@^1.0.0:
     object-visit "^1.0.0"
 
 markdown-escapes@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.1.tgz#1994df2d3af4811de59a6714934c2b2292734518"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.2.tgz#e639cbde7b99c841c0bacc8a07982873b46d2122"
 
 markdown-table@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.1.tgz#4b3dd3a133d1518b8ef0dbc709bf2a1b4824bc8c"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.2.tgz#c78db948fa879903a41bce522e3b96f801c63786"
 
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
@@ -6312,7 +6306,7 @@ micromatch@^2.1.5, micromatch@^2.3.11, micromatch@^2.3.7:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-micromatch@^3.0.0, micromatch@^3.1.4, micromatch@^3.1.8:
+micromatch@^3.0.0, micromatch@^3.1.4, micromatch@^3.1.8, micromatch@^3.1.9:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   dependencies:
@@ -6397,6 +6391,19 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
+minipass@^2.2.1, minipass@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.2.4.tgz#03c824d84551ec38a8d1bb5bc350a5a30a354a40"
+  dependencies:
+    safe-buffer "^5.1.1"
+    yallist "^3.0.0"
+
+minizlib@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.1.0.tgz#11e13658ce46bc3a70a267aac58359d1e0c29ceb"
+  dependencies:
+    minipass "^2.2.1"
+
 mississippi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/mississippi/-/mississippi-2.0.0.tgz#3442a508fafc28500486feea99409676e4ee5a6f"
@@ -6425,7 +6432,7 @@ mkdirp@0.5.0:
   dependencies:
     minimist "0.0.8"
 
-mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -6493,7 +6500,7 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
-nan@^2.3.0:
+nan@^2.9.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
 
@@ -6517,6 +6524,14 @@ nanomatch@^1.2.9:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+needle@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.0.tgz#f14efc69cee1024b72c8b21c7bdf94a731dc12fa"
+  dependencies:
+    debug "^2.1.2"
+    iconv-lite "^0.4.4"
+    sax "^1.2.4"
 
 negotiator@0.6.1:
   version "0.6.1"
@@ -6596,21 +6611,20 @@ node-notifier@^5.2.1:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-pre-gyp@^0.6.39:
-  version "0.6.39"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz#c00e96860b23c0e1420ac7befc5044e1d78d8649"
+node-pre-gyp@^0.9.0:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.9.1.tgz#f11c07516dd92f87199dbc7e1838eab7cd56c9e0"
   dependencies:
     detect-libc "^1.0.2"
-    hawk "3.1.3"
     mkdirp "^0.5.1"
+    needle "^2.2.0"
     nopt "^4.0.1"
+    npm-packlist "^1.1.6"
     npmlog "^4.0.2"
     rc "^1.1.7"
-    request "2.81.0"
     rimraf "^2.6.1"
     semver "^5.3.0"
-    tar "^2.2.1"
-    tar-pack "^3.4.0"
+    tar "^4"
 
 nomnom@^1.8.1:
   version "1.8.1"
@@ -6665,6 +6679,17 @@ normalize-url@^1.4.0:
     prepend-http "^1.0.0"
     query-string "^4.1.0"
     sort-keys "^1.0.0"
+
+npm-bundled@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.3.tgz#7e71703d973af3370a9591bafe3a63aca0be2308"
+
+npm-packlist@^1.1.6:
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.1.10.tgz#1039db9e985727e464df066f4cf0ab6ef85c398a"
+  dependencies:
+    ignore-walk "^3.0.1"
+    npm-bundled "^1.0.1"
 
 npm-path@^2.0.2:
   version "2.0.4"
@@ -6791,7 +6816,7 @@ on-headers@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.1.tgz#928f5d0f470d49342651ea6794b0857c100693f7"
 
-once@^1.3.0, once@^1.3.1, once@^1.3.3, once@^1.4.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
@@ -7143,8 +7168,8 @@ pause-stream@0.0.11:
     through "~2.3"
 
 pbkdf2@^3.0.3:
-  version "3.0.14"
-  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.14.tgz#a35e13c64799b06ce15320f459c230e68e73bade"
+  version "3.0.16"
+  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.16.tgz#7404208ec6b01b62d85bf83853a8064f8d9c2a5c"
   dependencies:
     create-hash "^1.1.2"
     create-hmac "^1.1.4"
@@ -7480,9 +7505,13 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@1.11.1, prettier@^1.5.3:
+prettier@1.11.1:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.11.1.tgz#61e43fc4cd44e68f2b0dfc2c38cd4bb0fccdcc75"
+
+prettier@^1.5.3:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.12.1.tgz#c1ad20e803e7749faf905a409d2367e06bbe7325"
 
 pretty-bytes@^4.0.2:
   version "4.0.2"
@@ -7653,9 +7682,9 @@ querystringify@0.0.x:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-0.0.4.tgz#0cf7f84f9463ff0ae51c4c4b142d95be37724d9c"
 
-querystringify@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-1.0.0.tgz#6286242112c5b712fa654e526652bf6a13ff05cb"
+querystringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.0.0.tgz#fa3ed6e68eb15159457c89b37bc6472833195755"
 
 ramda@0.24.1:
   version "0.24.1"
@@ -7828,7 +7857,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.9, readable-stream@^2.3.3, readable-stream@^2.3.5:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.9, readable-stream@^2.3.3, readable-stream@^2.3.5:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
@@ -8215,7 +8244,7 @@ require-uncached@^1.0.3:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
-requires-port@1.0.x, requires-port@1.x.x, requires-port@~1.0.0:
+requires-port@1.0.x, requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
@@ -8248,9 +8277,9 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.3, resolve@^1.1.6, resolve@^1.5.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.7.0.tgz#2bdf5374811207285df0df652b78f118ab8f3c5e"
+resolve@^1.1.3, resolve@^1.1.6, resolve@^1.5.0, resolve@^1.6.0:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.7.1.tgz#aadd656374fd298aee895bc026b8297418677fd3"
   dependencies:
     path-parse "^1.0.5"
 
@@ -8284,7 +8313,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
+rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
@@ -8295,10 +8324,10 @@ rimraf@~2.2.6:
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
 
 ripemd160@^2.0.0, ripemd160@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.1.tgz#0f4584295c53a3628af7e6d79aca21ce57d1c6e7"
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
   dependencies:
-    hash-base "^2.0.0"
+    hash-base "^3.0.0"
     inherits "^2.0.1"
 
 run-async@^2.0.0, run-async@^2.2.0:
@@ -8328,8 +8357,8 @@ rx-lite@*, rx-lite@^4.0.8:
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
 rxjs@^5.0.0-beta.11, rxjs@^5.4.2, rxjs@^5.5.2:
-  version "5.5.9"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.9.tgz#12a0487794b00f5eb370fec2751bd973a89886fb"
+  version "5.5.10"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.10.tgz#fde02d7a614f6c8683d0d1957827f492e09db045"
   dependencies:
     symbol-observable "1.0.1"
 
@@ -8419,8 +8448,8 @@ send@0.16.2:
     statuses "~1.4.0"
 
 serialize-javascript@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.4.0.tgz#7c958514db6ac2443a8abc062dc9f7886a7f6005"
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.5.0.tgz#1aa336162c88a890ddad5384baebc93a655161fe"
 
 serve-index@^1.7.2:
   version "1.9.1"
@@ -8663,8 +8692,8 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 space-separated-tokens@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.1.tgz#9695b9df9e65aec1811d4c3f9ce52520bc2f7e4d"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.2.tgz#e95ab9d19ae841e200808cd96bc7bd0adbbb3412"
   dependencies:
     trim "0.0.1"
 
@@ -8758,8 +8787,8 @@ staged-git-files@1.1.0:
   resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-1.1.0.tgz#1a9bb131c1885601023c7aaddd3d54c22142c526"
 
 state-toggle@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.0.tgz#d20f9a616bb4f0c3b98b91922d25b640aa2bc425"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.1.tgz#c3cb0974f40a6a0f8e905b96789eb41afa1cde3a"
 
 static-extend@^0.1.1:
   version "0.1.2"
@@ -9000,8 +9029,8 @@ supports-color@^4.0.0, supports-color@^4.1.0, supports-color@^4.2.1:
     has-flag "^2.0.0"
 
 supports-color@^5.1.0, supports-color@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.3.0.tgz#5b24ac15db80fa927cf5227a4a33fd3c4c7676c0"
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
   dependencies:
     has-flag "^3.0.0"
 
@@ -9048,26 +9077,17 @@ tapable@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.0.0.tgz#cbb639d9002eed9c6b5975eb20598d7936f1f9f2"
 
-tar-pack@^3.4.0:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.4.1.tgz#e1dbc03a9b9d3ba07e896ad027317eb679a10a1f"
+tar@^4:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.1.tgz#b25d5a8470c976fd7a9a8a350f42c59e9fa81749"
   dependencies:
-    debug "^2.2.0"
-    fstream "^1.0.10"
-    fstream-ignore "^1.0.5"
-    once "^1.3.3"
-    readable-stream "^2.1.4"
-    rimraf "^2.5.1"
-    tar "^2.2.1"
-    uid-number "^0.0.6"
-
-tar@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
-  dependencies:
-    block-stream "*"
-    fstream "^1.0.2"
-    inherits "2"
+    chownr "^1.0.1"
+    fs-minipass "^1.2.5"
+    minipass "^2.2.4"
+    minizlib "^1.1.0"
+    mkdirp "^0.5.0"
+    safe-buffer "^5.1.1"
+    yallist "^3.0.2"
 
 temp@^0.8.1:
   version "0.8.3"
@@ -9136,8 +9156,8 @@ timed-out@^4.0.0, timed-out@^4.0.1:
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
 
 timers-browserify@^2.0.4:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.6.tgz#241e76927d9ca05f4d959819022f5b3664b64bae"
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.10.tgz#1d28e3d2aadf1d5a5996c4e9f95601cd053480ae"
   dependencies:
     setimmediate "^1.0.4"
 
@@ -9225,8 +9245,8 @@ tr46@^1.0.0:
     punycode "^2.1.0"
 
 trim-lines@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-1.1.0.tgz#9926d03ede13ba18f7d42222631fb04c79ff26fe"
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-1.1.1.tgz#da738ff58fa74817588455e30b11b85289f2a396"
 
 trim-newlines@^1.0.0:
   version "1.0.0"
@@ -9245,8 +9265,8 @@ trim@0.0.1:
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
 
 trough@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.1.tgz#a9fd8b0394b0ae8fff82e0633a0a36ccad5b5f86"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.2.tgz#7f1663ec55c480139e2de5e486c6aef6cc24a535"
 
 tty-browserify@0.0.0:
   version "0.0.0"
@@ -9291,8 +9311,8 @@ uglify-es@^3.3.4:
     source-map "~0.6.1"
 
 uglify-js@3.3.x:
-  version "3.3.20"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.3.20.tgz#dc8bdee7d454c7d31dddc36f922d170bfcee3a0a"
+  version "3.3.22"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.3.22.tgz#e5f0e50ddd386b7e35b728b51600bf7a7ad0b0dc"
   dependencies:
     commander "~2.15.0"
     source-map "~0.6.1"
@@ -9319,8 +9339,8 @@ uglifyjs-webpack-plugin@^0.4.6:
     webpack-sources "^1.0.1"
 
 uglifyjs-webpack-plugin@^1.1.1:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.4.tgz#5eec941b2e9b8538be0a20fc6eda25b14c7c1043"
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.5.tgz#2ef8387c8f1a903ec5e44fa36f9f3cbdcea67641"
   dependencies:
     cacache "^10.0.4"
     find-cache-dir "^1.0.0"
@@ -9330,10 +9350,6 @@ uglifyjs-webpack-plugin@^1.1.1:
     uglify-es "^3.3.4"
     webpack-sources "^1.1.0"
     worker-farm "^1.5.2"
-
-uid-number@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
 
 unc-path-regex@^0.1.2:
   version "0.1.2"
@@ -9515,11 +9531,11 @@ url-parse@1.0.x:
     requires-port "1.0.x"
 
 url-parse@^1.1.8:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.3.0.tgz#04a06c420d22beb9804f7ada2d57ad13160a4258"
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.0.tgz#6bfdaad60098c7fe06f623e42b22de62de0d3d75"
   dependencies:
-    querystringify "~1.0.0"
-    requires-port "~1.0.0"
+    querystringify "^2.0.0"
+    requires-port "^1.0.0"
 
 url-to-options@^1.0.1:
   version "1.0.1"
@@ -9601,8 +9617,8 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
 
 vendors@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.1.tgz#37ad73c8ee417fb3d580e785312307d274847f22"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.2.tgz#7fcb5eef9f5623b156bcea89ec37d63676f21801"
 
 verror@1.10.0:
   version "1.10.0"
@@ -9780,9 +9796,9 @@ webpack-cli@2.0.12:
     yeoman-environment "^2.0.0"
     yeoman-generator "^2.0.3"
 
-webpack-dev-middleware@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-3.0.1.tgz#7ffd6d0192883c83d3f262e8d7dec822493c6166"
+webpack-dev-middleware@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-3.1.2.tgz#be4d0c36a4fa7d69d6904093418514caa9df3a40"
   dependencies:
     loud-rejection "^1.6.0"
     memory-fs "~0.4.1"
@@ -9792,9 +9808,9 @@ webpack-dev-middleware@3.0.1:
     url-join "^4.0.0"
     webpack-log "^1.0.1"
 
-webpack-dev-server@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-3.1.1.tgz#3c0fdd1ba3b50ebc79858a0e6b9ccdd1565b0c24"
+webpack-dev-server@3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-3.1.3.tgz#5cecfd8a9d60c4638284813f1cf9562f04e5c1c5"
   dependencies:
     ansi-html "0.0.7"
     array-includes "^3.0.3"
@@ -9806,7 +9822,7 @@ webpack-dev-server@3.1.1:
     del "^3.0.0"
     express "^4.16.2"
     html-entities "^1.2.0"
-    http-proxy-middleware "~0.17.4"
+    http-proxy-middleware "~0.18.0"
     import-local "^1.0.0"
     internal-ip "1.2.0"
     ip "^1.1.5"
@@ -9821,9 +9837,9 @@ webpack-dev-server@3.1.1:
     spdy "^3.4.1"
     strip-ansi "^3.0.0"
     supports-color "^5.1.0"
-    webpack-dev-middleware "3.0.1"
+    webpack-dev-middleware "3.1.2"
     webpack-log "^1.1.2"
-    yargs "9.0.1"
+    yargs "11.0.0"
 
 webpack-log@^1.0.1, webpack-log@^1.1.2:
   version "1.2.0"
@@ -10056,6 +10072,10 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
+yallist@^3.0.0, yallist@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
+
 yargs-parser@^4.2.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-4.2.1.tgz#29cceac0dc4f03c6c87b4a9f217dd18c9f74871c"
@@ -10080,23 +10100,22 @@ yargs-parser@^9.0.2:
   dependencies:
     camelcase "^4.1.0"
 
-yargs@9.0.1:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-9.0.1.tgz#52acc23feecac34042078ee78c0c007f5085db4c"
+yargs@11.0.0, yargs@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.0.0.tgz#c052931006c5eee74610e5fc0354bedfd08a201b"
   dependencies:
-    camelcase "^4.1.0"
-    cliui "^3.2.0"
+    cliui "^4.0.0"
     decamelize "^1.1.1"
+    find-up "^2.1.0"
     get-caller-file "^1.0.1"
     os-locale "^2.0.0"
-    read-pkg-up "^2.0.0"
     require-directory "^2.1.1"
     require-main-filename "^1.0.1"
     set-blocking "^2.0.0"
     string-width "^2.0.0"
     which-module "^2.0.0"
     y18n "^3.2.1"
-    yargs-parser "^7.0.0"
+    yargs-parser "^9.0.2"
 
 yargs@^10.0.3:
   version "10.1.2"
@@ -10114,23 +10133,6 @@ yargs@^10.0.3:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^8.1.0"
-
-yargs@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.0.0.tgz#c052931006c5eee74610e5fc0354bedfd08a201b"
-  dependencies:
-    cliui "^4.0.0"
-    decamelize "^1.1.1"
-    find-up "^2.1.0"
-    get-caller-file "^1.0.1"
-    os-locale "^2.0.0"
-    require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
-    set-blocking "^2.0.0"
-    string-width "^2.0.0"
-    which-module "^2.0.0"
-    y18n "^3.2.1"
-    yargs-parser "^9.0.2"
 
 yargs@^6.0.1:
   version "6.6.0"
@@ -10215,8 +10217,8 @@ yeoman-environment@^2.0.0, yeoman-environment@^2.0.5:
     untildify "^3.0.2"
 
 yeoman-generator@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/yeoman-generator/-/yeoman-generator-2.0.3.tgz#19426ed22687ffe05d31526c3f1c2cf67ba768f3"
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/yeoman-generator/-/yeoman-generator-2.0.4.tgz#c1c51580ab88506233dd6e837a4bbf8a8e34c9a6"
   dependencies:
     async "^2.6.0"
     chalk "^2.3.0"


### PR DESCRIPTION
- Logic for highlight updates is now  isolated in `graph.helper.js`
- `_setNodeHighlightedValue` simply fetches state from new method
- Extras
  - Fix jest coverage reports
  - Update `webpack-dev-server` to 3.1.3
  - Formated `Sandbox.jsx` and `Graph.jsx`