### PR TITLE
Fix/peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
             "requires": {
                 "@babel/types": "7.0.0-beta.44",
                 "jsesc": "2.5.1",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "source-map": "0.5.7",
                 "trim-right": "1.0.1"
             },
@@ -69,7 +69,7 @@
             "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.0",
+                "chalk": "2.4.1",
                 "esutils": "2.0.2",
                 "js-tokens": "3.0.2"
             },
@@ -84,9 +84,9 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
@@ -120,7 +120,7 @@
                 "@babel/code-frame": "7.0.0-beta.44",
                 "@babel/types": "7.0.0-beta.44",
                 "babylon": "7.0.0-beta.44",
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
             },
             "dependencies": {
                 "babylon": {
@@ -144,9 +144,9 @@
                 "@babel/types": "7.0.0-beta.44",
                 "babylon": "7.0.0-beta.44",
                 "debug": "3.1.0",
-                "globals": "11.4.0",
+                "globals": "11.5.0",
                 "invariant": "2.2.4",
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
             },
             "dependencies": {
                 "babylon": {
@@ -156,9 +156,9 @@
                     "dev": true
                 },
                 "globals": {
-                    "version": "11.4.0",
-                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
-                    "integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA==",
+                    "version": "11.5.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.5.0.tgz",
+                    "integrity": "sha512-hYyf+kI8dm3nORsiiXUQigOU62hDLfJ9G01uyGMxhc6BKsircrUhC4uJPQPUSuq2GrTmiiEt7ewxlMdBewfmKQ==",
                     "dev": true
                 }
             }
@@ -170,7 +170,7 @@
             "dev": true,
             "requires": {
                 "esutils": "2.0.2",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "to-fast-properties": "2.0.0"
             },
             "dependencies": {
@@ -244,7 +244,7 @@
                         "supports-color": "4.5.0",
                         "tapable": "0.2.8",
                         "uglifyjs-webpack-plugin": "0.4.6",
-                        "watchpack": "1.5.0",
+                        "watchpack": "1.6.0",
                         "webpack-sources": "1.1.0",
                         "yargs": "8.0.2"
                     }
@@ -258,6 +258,16 @@
             "dev": true,
             "requires": {
                 "lodash.once": "4.1.1"
+            }
+        },
+        "@mrmlnc/readdir-enhanced": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+            "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+            "dev": true,
+            "requires": {
+                "call-me-maybe": "1.0.1",
+                "glob-to-regexp": "0.3.0"
             }
         },
         "@sindresorhus/is": {
@@ -349,13 +359,6 @@
             "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
             "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
             "dev": true
-        },
-        "abbrev": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-            "dev": true,
-            "optional": true
         },
         "accepts": {
             "version": "1.3.5",
@@ -518,17 +521,6 @@
             "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
             "dev": true
         },
-        "are-we-there-yet": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-            "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "delegates": "1.0.0",
-                "readable-stream": "2.3.6"
-            }
-        },
         "argparse": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -644,7 +636,8 @@
         "asap": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-            "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+            "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+            "dev": true
         },
         "asn1": {
             "version": "0.2.3",
@@ -702,7 +695,7 @@
             "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
             "dev": true,
             "requires": {
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
             }
         },
         "async-each": {
@@ -724,9 +717,9 @@
             "dev": true
         },
         "atob": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz",
-            "integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
+            "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
             "dev": true
         },
         "autoprefixer": {
@@ -736,7 +729,7 @@
             "dev": true,
             "requires": {
                 "browserslist": "1.7.7",
-                "caniuse-db": "1.0.30000830",
+                "caniuse-db": "1.0.30000839",
                 "normalize-range": "0.1.2",
                 "num2fraction": "1.2.2",
                 "postcss": "5.2.18",
@@ -749,8 +742,8 @@
                     "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
                     "dev": true,
                     "requires": {
-                        "caniuse-db": "1.0.30000830",
-                        "electron-to-chromium": "1.3.42"
+                        "caniuse-db": "1.0.30000839",
+                        "electron-to-chromium": "1.3.45"
                     }
                 }
             }
@@ -782,7 +775,7 @@
                 "convert-source-map": "1.5.1",
                 "fs-readdir-recursive": "1.1.0",
                 "glob": "7.1.2",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "output-file-sync": "1.1.2",
                 "path-is-absolute": "1.0.1",
                 "slash": "1.0.0",
@@ -839,7 +832,7 @@
                     "requires": {
                         "anymatch": "1.3.2",
                         "async-each": "1.0.1",
-                        "fsevents": "1.2.0",
+                        "fsevents": "1.2.3",
                         "glob-parent": "2.0.0",
                         "inherits": "2.0.3",
                         "is-binary-path": "1.0.1",
@@ -947,7 +940,7 @@
                 "convert-source-map": "1.5.1",
                 "debug": "2.6.9",
                 "json5": "0.5.1",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "minimatch": "3.0.4",
                 "path-is-absolute": "1.0.1",
                 "private": "0.1.8",
@@ -999,7 +992,7 @@
                 "babel-types": "6.26.0",
                 "detect-indent": "4.0.0",
                 "jsesc": "1.3.0",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "source-map": "0.5.7",
                 "trim-right": "1.0.1"
             }
@@ -1058,7 +1051,7 @@
                 "babel-helper-function-name": "6.24.1",
                 "babel-runtime": "6.26.0",
                 "babel-types": "6.26.0",
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
             }
         },
         "babel-helper-explode-assignable-expression": {
@@ -1135,7 +1128,7 @@
             "requires": {
                 "babel-runtime": "6.26.0",
                 "babel-types": "6.26.0",
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
             }
         },
         "babel-helper-remap-async-to-generator": {
@@ -1444,7 +1437,7 @@
                 "babel-template": "6.26.0",
                 "babel-traverse": "6.26.0",
                 "babel-types": "6.26.0",
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
             }
         },
         "babel-plugin-transform-es2015-classes": {
@@ -1528,15 +1521,15 @@
             "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
             "dev": true,
             "requires": {
-                "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+                "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
                 "babel-runtime": "6.26.0",
                 "babel-template": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-modules-commonjs": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
-            "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+            "version": "6.26.2",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+            "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
             "dev": true,
             "requires": {
                 "babel-plugin-transform-strict-mode": "6.24.1",
@@ -1767,7 +1760,7 @@
             "dev": true,
             "requires": {
                 "babel-runtime": "6.26.0",
-                "core-js": "2.5.5",
+                "core-js": "2.5.6",
                 "regenerator-runtime": "0.10.5"
             },
             "dependencies": {
@@ -1799,7 +1792,7 @@
                 "babel-plugin-transform-es2015-function-name": "6.24.1",
                 "babel-plugin-transform-es2015-literals": "6.22.0",
                 "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-                "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+                "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
                 "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
                 "babel-plugin-transform-es2015-modules-umd": "6.24.1",
                 "babel-plugin-transform-es2015-object-super": "6.24.1",
@@ -1835,7 +1828,7 @@
                 "babel-plugin-transform-es2015-function-name": "6.24.1",
                 "babel-plugin-transform-es2015-literals": "6.22.0",
                 "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-                "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+                "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
                 "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
                 "babel-plugin-transform-es2015-modules-umd": "6.24.1",
                 "babel-plugin-transform-es2015-object-super": "6.24.1",
@@ -1947,9 +1940,9 @@
             "requires": {
                 "babel-core": "6.26.0",
                 "babel-runtime": "6.26.0",
-                "core-js": "2.5.5",
+                "core-js": "2.5.6",
                 "home-or-tmp": "2.0.0",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "mkdirp": "0.5.1",
                 "source-map-support": "0.4.18"
             }
@@ -1960,7 +1953,7 @@
             "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
             "dev": true,
             "requires": {
-                "core-js": "2.5.5",
+                "core-js": "2.5.6",
                 "regenerator-runtime": "0.11.1"
             }
         },
@@ -1974,7 +1967,7 @@
                 "babel-traverse": "6.26.0",
                 "babel-types": "6.26.0",
                 "babylon": "6.18.0",
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
             }
         },
         "babel-traverse": {
@@ -1991,7 +1984,7 @@
                 "debug": "2.6.9",
                 "globals": "9.18.0",
                 "invariant": "2.2.4",
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
             },
             "dependencies": {
                 "debug": {
@@ -2013,7 +2006,7 @@
             "requires": {
                 "babel-runtime": "6.26.0",
                 "esutils": "2.0.2",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "to-fast-properties": "1.0.3"
             }
         },
@@ -2369,7 +2362,7 @@
                 "create-hash": "1.2.0",
                 "evp_bytestokey": "1.0.3",
                 "inherits": "2.0.3",
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "browserify-cipher": {
@@ -2434,8 +2427,8 @@
             "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "1.0.30000830",
-                "electron-to-chromium": "1.3.42"
+                "caniuse-lite": "1.0.30000839",
+                "electron-to-chromium": "1.3.45"
             }
         },
         "bser": {
@@ -2462,6 +2455,12 @@
             "version": "0.2.13",
             "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
             "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+            "dev": true
+        },
+        "buffer-from": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+            "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
             "dev": true
         },
         "buffer-indexof": {
@@ -2510,7 +2509,7 @@
                 "chownr": "1.0.1",
                 "glob": "7.1.2",
                 "graceful-fs": "4.1.11",
-                "lru-cache": "4.1.2",
+                "lru-cache": "4.1.3",
                 "mississippi": "2.0.0",
                 "mkdirp": "0.5.1",
                 "move-concurrently": "1.0.1",
@@ -2612,6 +2611,12 @@
                 }
             }
         },
+        "call-me-maybe": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+            "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+            "dev": true
+        },
         "caller-path": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
@@ -2668,7 +2673,7 @@
             "dev": true,
             "requires": {
                 "browserslist": "1.7.7",
-                "caniuse-db": "1.0.30000830",
+                "caniuse-db": "1.0.30000839",
                 "lodash.memoize": "4.1.2",
                 "lodash.uniq": "4.5.0"
             },
@@ -2679,23 +2684,32 @@
                     "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
                     "dev": true,
                     "requires": {
-                        "caniuse-db": "1.0.30000830",
-                        "electron-to-chromium": "1.3.42"
+                        "caniuse-db": "1.0.30000839",
+                        "electron-to-chromium": "1.3.45"
                     }
                 }
             }
         },
         "caniuse-db": {
-            "version": "1.0.30000830",
-            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000830.tgz",
-            "integrity": "sha1-bkUlWzRWSf0V/1kHLaHhK7PeLxM=",
+            "version": "1.0.30000839",
+            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000839.tgz",
+            "integrity": "sha1-VahuQCx0rhcUlwe+o+o5lSIjNJc=",
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30000830",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000830.tgz",
-            "integrity": "sha512-yMqGkujkoOIZfvOYiWdqPALgY/PVGiqCHUJb6yNq7xhI/pR+gQO0U2K6lRDqAiJv4+CIU3CtTLblNGw0QGnr6g==",
+            "version": "1.0.30000839",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000839.tgz",
+            "integrity": "sha512-gJZIfmkuy84agOeAZc7WJOexZhisZaBSFk96gkGM6TkH7+1mBfr/MSPnXC8lO0g7guh/ucbswYjruvDbzc6i0g==",
             "dev": true
+        },
+        "capture-exit": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
+            "integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
+            "dev": true,
+            "requires": {
+                "rsvp": "3.6.2"
+            }
         },
         "caseless": {
             "version": "0.12.0",
@@ -2777,7 +2791,7 @@
                 "anymatch": "2.0.0",
                 "async-each": "1.0.1",
                 "braces": "2.3.2",
-                "fsevents": "1.2.0",
+                "fsevents": "1.2.3",
                 "glob-parent": "3.1.0",
                 "inherits": "2.0.3",
                 "is-binary-path": "1.0.1",
@@ -2785,7 +2799,7 @@
                 "normalize-path": "2.1.1",
                 "path-is-absolute": "1.0.1",
                 "readdirp": "2.1.0",
-                "upath": "1.0.4"
+                "upath": "1.0.5"
             }
         },
         "chownr": {
@@ -2813,7 +2827,7 @@
             "dev": true,
             "requires": {
                 "inherits": "2.0.3",
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "circular-json": {
@@ -2903,6 +2917,19 @@
             "requires": {
                 "slice-ansi": "0.0.4",
                 "string-width": "1.0.2"
+            },
+            "dependencies": {
+                "string-width": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                    }
+                }
             }
         },
         "cli-width": {
@@ -3070,7 +3097,8 @@
         "commander": {
             "version": "2.15.1",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-            "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+            "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+            "dev": true
         },
         "common-tags": {
             "version": "1.4.0",
@@ -3097,7 +3125,7 @@
                 "detective": "4.7.1",
                 "glob": "5.0.15",
                 "graceful-fs": "4.1.11",
-                "iconv-lite": "0.4.21",
+                "iconv-lite": "0.4.23",
                 "mkdirp": "0.5.1",
                 "private": "0.1.8",
                 "q": "1.5.1",
@@ -3193,6 +3221,12 @@
                     "requires": {
                         "ms": "2.0.0"
                     }
+                },
+                "safe-buffer": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+                    "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+                    "dev": true
                 }
             }
         },
@@ -3227,12 +3261,6 @@
             "requires": {
                 "date-now": "0.1.4"
             }
-        },
-        "console-control-strings": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-            "dev": true
         },
         "constants-browserify": {
             "version": "1.0.0",
@@ -3303,9 +3331,9 @@
             "dev": true
         },
         "core-js": {
-            "version": "2.5.5",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-            "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
+            "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ==",
             "dev": true
         },
         "core-util-is": {
@@ -3361,9 +3389,9 @@
             }
         },
         "create-ecdh": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.1.tgz",
-            "integrity": "sha512-iZvCCg8XqHQZ1ioNBTzXS/cQSkqkqcPs8xSX4upNB+DAk9Ht3uzQf2J32uAHNCne8LDmKr29AgZrEs4oIrwLuQ==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
+            "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
             "dev": true,
             "requires": {
                 "bn.js": "4.11.8",
@@ -3393,7 +3421,7 @@
                 "create-hash": "1.2.0",
                 "inherits": "2.0.3",
                 "ripemd160": "2.0.2",
-                "safe-buffer": "5.1.1",
+                "safe-buffer": "5.1.2",
                 "sha.js": "2.4.11"
             }
         },
@@ -3401,6 +3429,7 @@
             "version": "15.6.3",
             "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
             "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
+            "dev": true,
             "requires": {
                 "fbjs": "0.8.16",
                 "loose-envify": "1.3.1",
@@ -3413,7 +3442,7 @@
             "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
             "dev": true,
             "requires": {
-                "lru-cache": "4.1.2",
+                "lru-cache": "4.1.3",
                 "shebang-command": "1.2.0",
                 "which": "1.3.0"
             }
@@ -3435,7 +3464,7 @@
             "requires": {
                 "browserify-cipher": "1.0.1",
                 "browserify-sign": "4.0.4",
-                "create-ecdh": "4.0.1",
+                "create-ecdh": "4.0.3",
                 "create-hash": "1.2.0",
                 "create-hmac": "1.1.7",
                 "diffie-hellman": "5.0.3",
@@ -3716,116 +3745,128 @@
             }
         },
         "d3": {
-            "version": "4.10.2",
-            "resolved": "https://registry.npmjs.org/d3/-/d3-4.10.2.tgz",
-            "integrity": "sha512-0PxXZbD+Remq9x4wdes1gs6rYcGJKA3+e0xwbma0r4ricKOKBHUHfDWcxKQICS3ZZxhzwNYWl196pxDqcAgRpw==",
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/d3/-/d3-4.13.0.tgz",
+            "integrity": "sha512-l8c4+0SldjVKLaE2WG++EQlqD7mh/dmQjvi2L2lKPadAVC+TbJC4ci7Uk9bRi+To0+ansgsS0iWfPjD7DBy+FQ==",
+            "dev": true,
             "requires": {
-                "d3-array": "1.2.0",
+                "d3-array": "1.2.1",
                 "d3-axis": "1.0.8",
                 "d3-brush": "1.0.4",
                 "d3-chord": "1.0.4",
                 "d3-collection": "1.0.4",
                 "d3-color": "1.0.3",
                 "d3-dispatch": "1.0.3",
-                "d3-drag": "1.1.1",
-                "d3-dsv": "1.0.7",
+                "d3-drag": "1.2.1",
+                "d3-dsv": "1.0.8",
                 "d3-ease": "1.0.3",
-                "d3-force": "1.0.6",
-                "d3-format": "1.2.0",
-                "d3-geo": "1.6.4",
+                "d3-force": "1.1.0",
+                "d3-format": "1.2.2",
+                "d3-geo": "1.9.1",
                 "d3-hierarchy": "1.1.5",
-                "d3-interpolate": "1.1.5",
+                "d3-interpolate": "1.1.6",
                 "d3-path": "1.0.5",
                 "d3-polygon": "1.0.3",
                 "d3-quadtree": "1.0.3",
                 "d3-queue": "3.0.7",
                 "d3-random": "1.1.0",
                 "d3-request": "1.0.6",
-                "d3-scale": "1.0.6",
-                "d3-selection": "1.1.0",
+                "d3-scale": "1.0.7",
+                "d3-selection": "1.3.0",
                 "d3-shape": "1.2.0",
-                "d3-time": "1.0.7",
-                "d3-time-format": "2.0.5",
+                "d3-time": "1.0.8",
+                "d3-time-format": "2.1.1",
                 "d3-timer": "1.0.7",
-                "d3-transition": "1.1.0",
+                "d3-transition": "1.1.1",
                 "d3-voronoi": "1.1.2",
-                "d3-zoom": "1.5.0"
+                "d3-zoom": "1.7.1"
             }
         },
         "d3-array": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.0.tgz",
-            "integrity": "sha1-FH0mlyDhdMQFen9CvosPPyulMQg="
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.1.tgz",
+            "integrity": "sha512-CyINJQ0SOUHojDdFDH4JEM0552vCR1utGyLHegJHyYH0JyCpSeTPxi4OBqHMA2jJZq4NH782LtaJWBImqI/HBw==",
+            "dev": true
         },
         "d3-axis": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-1.0.8.tgz",
-            "integrity": "sha1-MacFoLU15ldZ3hQXOjGTMTfxjvo="
+            "integrity": "sha1-MacFoLU15ldZ3hQXOjGTMTfxjvo=",
+            "dev": true
         },
         "d3-brush": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.0.4.tgz",
             "integrity": "sha1-AMLyOAGfJPbAoZSibUGhUw/+e8Q=",
+            "dev": true,
             "requires": {
                 "d3-dispatch": "1.0.3",
-                "d3-drag": "1.1.1",
-                "d3-interpolate": "1.1.5",
-                "d3-selection": "1.1.0",
-                "d3-transition": "1.1.0"
+                "d3-drag": "1.2.1",
+                "d3-interpolate": "1.1.6",
+                "d3-selection": "1.3.0",
+                "d3-transition": "1.1.1"
             }
         },
         "d3-chord": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-1.0.4.tgz",
             "integrity": "sha1-fexPC6iG9xP+ERxF92NBT290yiw=",
+            "dev": true,
             "requires": {
-                "d3-array": "1.2.0",
+                "d3-array": "1.2.1",
                 "d3-path": "1.0.5"
             }
         },
         "d3-collection": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.4.tgz",
-            "integrity": "sha1-NC39EoN8kJdPM/HMCnha6lcNzcI="
+            "integrity": "sha1-NC39EoN8kJdPM/HMCnha6lcNzcI=",
+            "dev": true
         },
         "d3-color": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.0.3.tgz",
-            "integrity": "sha1-vHZD/KjlOoNH4vva/6I2eWtYUJs="
+            "integrity": "sha1-vHZD/KjlOoNH4vva/6I2eWtYUJs=",
+            "dev": true
         },
         "d3-dispatch": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.3.tgz",
-            "integrity": "sha1-RuFJHqqbWMNY/OW+TovtYm54cfg="
+            "integrity": "sha1-RuFJHqqbWMNY/OW+TovtYm54cfg=",
+            "dev": true
         },
         "d3-drag": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.1.1.tgz",
-            "integrity": "sha512-51aazbUuZZhPZzXv9xxwPOJTeDSVv8cXNd8oFxqJyR8ZBD9yLd09CFGSDSm3ArViHg2D5Wo1qCaKl7Efj/qchg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.1.tgz",
+            "integrity": "sha512-Cg8/K2rTtzxzrb0fmnYOUeZHvwa4PHzwXOLZZPwtEs2SKLLKLXeYwZKBB+DlOxUvFmarOnmt//cU4+3US2lyyQ==",
+            "dev": true,
             "requires": {
                 "d3-dispatch": "1.0.3",
-                "d3-selection": "1.1.0"
+                "d3-selection": "1.3.0"
             }
         },
         "d3-dsv": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.0.7.tgz",
-            "integrity": "sha512-12szKhDhM/tM5U/Ch3hyJ7sMdcwPqMRmrUWitLLdPBMKO9Wuox95ezKZvemy/fxFbefLF/HIPKUmJMBLLuFDaQ==",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.0.8.tgz",
+            "integrity": "sha512-IVCJpQ+YGe3qu6odkPQI0KPqfxkhbP/oM1XhhE/DFiYmcXKfCRub4KXyiuehV1d4drjWVXHUWx4gHqhdZb6n/A==",
+            "dev": true,
             "requires": {
                 "commander": "2.15.1",
-                "iconv-lite": "0.4.21",
+                "iconv-lite": "0.4.23",
                 "rw": "1.3.3"
             }
         },
         "d3-ease": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.3.tgz",
-            "integrity": "sha1-aL+8NJM4o4DETYrMT7wzBKotjA4="
+            "integrity": "sha1-aL+8NJM4o4DETYrMT7wzBKotjA4=",
+            "dev": true
         },
         "d3-force": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.0.6.tgz",
-            "integrity": "sha1-6n4bdzDiZkzTFPWU1nGMV8wTK3k=",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.1.0.tgz",
+            "integrity": "sha512-2HVQz3/VCQs0QeRNZTYb7GxoUCeb6bOzMp/cGcLa87awY9ZsPvXOGeZm0iaGBjXic6I1ysKwMn+g+5jSAdzwcg==",
+            "dev": true,
             "requires": {
                 "d3-collection": "1.0.4",
                 "d3-dispatch": "1.0.3",
@@ -3834,27 +3875,31 @@
             }
         },
         "d3-format": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.2.0.tgz",
-            "integrity": "sha1-a0gLqohohdRlHcJIqPSsnaFtsHo="
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.2.2.tgz",
+            "integrity": "sha512-zH9CfF/3C8zUI47nsiKfD0+AGDEuM8LwBIP7pBVpyR4l/sKkZqITmMtxRp04rwBrlshIZ17XeFAaovN3++wzkw==",
+            "dev": true
         },
         "d3-geo": {
-            "version": "1.6.4",
-            "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.6.4.tgz",
-            "integrity": "sha1-8g4eRhyxhF9ai+Vatvh2VCp+MZk=",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.9.1.tgz",
+            "integrity": "sha512-l9wL/cEQkyZQYXw3xbmLsH3eQ5ij+icNfo4r0GrLa5rOCZR/e/3am45IQ0FvQ5uMsv+77zBRunLc9ufTWSQYFA==",
+            "dev": true,
             "requires": {
-                "d3-array": "1.2.0"
+                "d3-array": "1.2.1"
             }
         },
         "d3-hierarchy": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.5.tgz",
-            "integrity": "sha1-ochFxC+Eoga88cAcAQmOpN2qeiY="
+            "integrity": "sha1-ochFxC+Eoga88cAcAQmOpN2qeiY=",
+            "dev": true
         },
         "d3-interpolate": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.1.5.tgz",
-            "integrity": "sha1-aeCZ/zkhRxblY8muw+qdHqS4p58=",
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.1.6.tgz",
+            "integrity": "sha512-mOnv5a+pZzkNIHtw/V6I+w9Lqm9L5bG3OTXPM5A+QO0yyVMQ4W1uZhR+VOJmazaOZXri2ppbiZ5BUNWT0pFM9A==",
+            "dev": true,
             "requires": {
                 "d3-color": "1.0.3"
             }
@@ -3862,112 +3907,127 @@
         "d3-path": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.5.tgz",
-            "integrity": "sha1-JB6xhJvZ6egCHA0KeZ+KDo5EF2Q="
+            "integrity": "sha1-JB6xhJvZ6egCHA0KeZ+KDo5EF2Q=",
+            "dev": true
         },
         "d3-polygon": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-1.0.3.tgz",
-            "integrity": "sha1-FoiOkCZGCTPysXllKtN4Ik04LGI="
+            "integrity": "sha1-FoiOkCZGCTPysXllKtN4Ik04LGI=",
+            "dev": true
         },
         "d3-quadtree": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.3.tgz",
-            "integrity": "sha1-rHmH4+I/6AWpkPKOG1DTj8uCJDg="
+            "integrity": "sha1-rHmH4+I/6AWpkPKOG1DTj8uCJDg=",
+            "dev": true
         },
         "d3-queue": {
             "version": "3.0.7",
             "resolved": "https://registry.npmjs.org/d3-queue/-/d3-queue-3.0.7.tgz",
-            "integrity": "sha1-yTouVLQXwJWRKdfXP2z31Ckudhg="
+            "integrity": "sha1-yTouVLQXwJWRKdfXP2z31Ckudhg=",
+            "dev": true
         },
         "d3-random": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-1.1.0.tgz",
-            "integrity": "sha1-ZkLlBsb6OmSFldKyRpeIqNElKdM="
+            "integrity": "sha1-ZkLlBsb6OmSFldKyRpeIqNElKdM=",
+            "dev": true
         },
         "d3-request": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/d3-request/-/d3-request-1.0.6.tgz",
             "integrity": "sha512-FJj8ySY6GYuAJHZMaCQ83xEYE4KbkPkmxZ3Hu6zA1xxG2GD+z6P+Lyp+zjdsHf0xEbp2xcluDI50rCS855EQ6w==",
+            "dev": true,
             "requires": {
                 "d3-collection": "1.0.4",
                 "d3-dispatch": "1.0.3",
-                "d3-dsv": "1.0.7",
+                "d3-dsv": "1.0.8",
                 "xmlhttprequest": "1.8.0"
             }
         },
         "d3-scale": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.6.tgz",
-            "integrity": "sha1-vOGdqA06DPQiyVQ64zIghiILNO0=",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+            "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+            "dev": true,
             "requires": {
-                "d3-array": "1.2.0",
+                "d3-array": "1.2.1",
                 "d3-collection": "1.0.4",
                 "d3-color": "1.0.3",
-                "d3-format": "1.2.0",
-                "d3-interpolate": "1.1.5",
-                "d3-time": "1.0.7",
-                "d3-time-format": "2.0.5"
+                "d3-format": "1.2.2",
+                "d3-interpolate": "1.1.6",
+                "d3-time": "1.0.8",
+                "d3-time-format": "2.1.1"
             }
         },
         "d3-selection": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.1.0.tgz",
-            "integrity": "sha1-GZhoSJZIj4OcoDchI9o08dMYgJw="
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.3.0.tgz",
+            "integrity": "sha512-qgpUOg9tl5CirdqESUAu0t9MU/t3O9klYfGfyKsXEmhyxyzLpzpeh08gaxBUTQw1uXIOkr/30Ut2YRjSSxlmHA==",
+            "dev": true
         },
         "d3-shape": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.2.0.tgz",
             "integrity": "sha1-RdAVOPBkuv0F6j1tLLdI/YxB93c=",
+            "dev": true,
             "requires": {
                 "d3-path": "1.0.5"
             }
         },
         "d3-time": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.7.tgz",
-            "integrity": "sha1-lMr27bt4ebuAnQ0fdXK8SEgvcnA="
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.8.tgz",
+            "integrity": "sha512-YRZkNhphZh3KcnBfitvF3c6E0JOFGikHZ4YqD+Lzv83ZHn1/u6yGenRU1m+KAk9J1GnZMnKcrtfvSktlA1DXNQ==",
+            "dev": true
         },
         "d3-time-format": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.0.5.tgz",
-            "integrity": "sha1-nXeAIE98kRnJFwsaVttN6aivly4=",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.1.tgz",
+            "integrity": "sha512-8kAkymq2WMfzW7e+s/IUNAtN/y3gZXGRrdGfo6R8NKPAA85UBTxZg5E61bR6nLwjPjj4d3zywSQe1CkYLPFyrw==",
+            "dev": true,
             "requires": {
-                "d3-time": "1.0.7"
+                "d3-time": "1.0.8"
             }
         },
         "d3-timer": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.7.tgz",
-            "integrity": "sha512-vMZXR88XujmG/L5oB96NNKH5lCWwiLM/S2HyyAQLcjWJCloK5shxta4CwOFYLZoY3AWX73v8Lgv4cCAdWtRmOA=="
+            "integrity": "sha512-vMZXR88XujmG/L5oB96NNKH5lCWwiLM/S2HyyAQLcjWJCloK5shxta4CwOFYLZoY3AWX73v8Lgv4cCAdWtRmOA==",
+            "dev": true
         },
         "d3-transition": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.1.0.tgz",
-            "integrity": "sha1-z8hcdOUjkyQpBUZiNXKZBWDDlm8=",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.1.1.tgz",
+            "integrity": "sha512-xeg8oggyQ+y5eb4J13iDgKIjUcEfIOZs2BqV/eEmXm2twx80wTzJ4tB4vaZ5BKfz7XsI/DFmQL5me6O27/5ykQ==",
+            "dev": true,
             "requires": {
                 "d3-color": "1.0.3",
                 "d3-dispatch": "1.0.3",
                 "d3-ease": "1.0.3",
-                "d3-interpolate": "1.1.5",
-                "d3-selection": "1.1.0",
+                "d3-interpolate": "1.1.6",
+                "d3-selection": "1.3.0",
                 "d3-timer": "1.0.7"
             }
         },
         "d3-voronoi": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
-            "integrity": "sha1-Fodmfo8TotFYyAwUgMWinLDYlzw="
+            "integrity": "sha1-Fodmfo8TotFYyAwUgMWinLDYlzw=",
+            "dev": true
         },
         "d3-zoom": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.5.0.tgz",
-            "integrity": "sha512-tc/ONeSUVuwHczjjK4jQPd0T1iZ+lfsz8TbguAAceY5qs057hp4WLglkPWValkuVjCyeGpqiA2iTm8S++NJ84w==",
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.7.1.tgz",
+            "integrity": "sha512-sZHQ55DGq5BZBFGnRshUT8tm2sfhPHFnOlmPbbwTkAoPeVdRTkB4Xsf9GCY0TSHrTD8PeJPZGmP/TpGicwJDJQ==",
+            "dev": true,
             "requires": {
                 "d3-dispatch": "1.0.3",
-                "d3-drag": "1.1.1",
-                "d3-interpolate": "1.1.5",
-                "d3-selection": "1.1.0",
-                "d3-transition": "1.1.0"
+                "d3-drag": "1.2.1",
+                "d3-interpolate": "1.1.6",
+                "d3-selection": "1.3.0",
+                "d3-transition": "1.1.1"
             }
         },
         "dargs": {
@@ -4001,7 +4061,7 @@
             "requires": {
                 "abab": "1.0.4",
                 "whatwg-mimetype": "2.1.0",
-                "whatwg-url": "6.4.0"
+                "whatwg-url": "6.4.1"
             }
         },
         "date-fns": {
@@ -4065,9 +4125,9 @@
             "dev": true
         },
         "deep-extend": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-            "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+            "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
             "dev": true
         },
         "deep-is": {
@@ -4188,13 +4248,6 @@
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
             "dev": true
         },
-        "delegates": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-            "dev": true,
-            "optional": true
-        },
         "depd": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -4241,13 +4294,6 @@
                 "repeating": "2.0.1"
             }
         },
-        "detect-libc": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-            "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-            "dev": true,
-            "optional": true
-        },
         "detect-newline": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
@@ -4287,6 +4333,27 @@
                 "randombytes": "2.0.6"
             }
         },
+        "dir-glob": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+            "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+            "dev": true,
+            "requires": {
+                "arrify": "1.0.1",
+                "path-type": "3.0.0"
+            },
+            "dependencies": {
+                "path-type": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+                    "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+                    "dev": true,
+                    "requires": {
+                        "pify": "3.0.0"
+                    }
+                }
+            }
+        },
         "disparity": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/disparity/-/disparity-2.0.0.tgz",
@@ -4310,7 +4377,7 @@
             "dev": true,
             "requires": {
                 "ip": "1.1.5",
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "dns-txt": {
@@ -4359,7 +4426,7 @@
                 "babel-types": "6.26.0",
                 "babelify": "7.3.0",
                 "babylon": "6.18.0",
-                "chalk": "2.4.0",
+                "chalk": "2.4.1",
                 "chokidar": "1.7.0",
                 "concat-stream": "1.6.0",
                 "disparity": "2.0.0",
@@ -4371,7 +4438,7 @@
                 "globals-docs": "2.4.0",
                 "highlight.js": "9.12.0",
                 "js-yaml": "3.11.0",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "mdast-util-inject": "1.1.0",
                 "micromatch": "3.1.10",
                 "mime": "1.6.0",
@@ -4388,10 +4455,10 @@
                 "strip-json-comments": "2.0.1",
                 "tiny-lr": "1.1.1",
                 "unist-builder": "1.0.2",
-                "unist-util-visit": "1.3.0",
+                "unist-util-visit": "1.3.1",
                 "vfile": "2.3.0",
                 "vfile-reporter": "4.0.0",
-                "vfile-sort": "2.1.0",
+                "vfile-sort": "2.1.1",
                 "vinyl": "2.1.0",
                 "vinyl-fs": "2.4.4",
                 "yargs": "6.6.0"
@@ -4472,9 +4539,9 @@
                     "dev": true
                 },
                 "chalk": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
@@ -4490,7 +4557,7 @@
                     "requires": {
                         "anymatch": "1.3.2",
                         "async-each": "1.0.1",
-                        "fsevents": "1.2.0",
+                        "fsevents": "1.2.3",
                         "glob-parent": "2.0.0",
                         "inherits": "2.0.3",
                         "is-binary-path": "1.0.1",
@@ -4651,6 +4718,17 @@
                         "load-json-file": "1.1.0",
                         "normalize-package-data": "2.4.0",
                         "path-type": "1.1.0"
+                    }
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
                     }
                 },
                 "strip-bom": {
@@ -4818,9 +4896,9 @@
             "dev": true
         },
         "duplexify": {
-            "version": "3.5.4",
-            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
-            "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+            "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
             "dev": true,
             "requires": {
                 "end-of-stream": "1.4.1",
@@ -4872,15 +4950,15 @@
             "dev": true
         },
         "ejs": {
-            "version": "2.5.9",
-            "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.9.tgz",
-            "integrity": "sha512-GJCAeDBKfREgkBtgrYSf9hQy9kTb3helv0zGdzqhM7iAkW8FA/ZF97VQDbwFiwIT8MQLLOe5VlPZOEvZAqtUAQ==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
+            "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==",
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.3.42",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.42.tgz",
-            "integrity": "sha1-lcM78B0MxAVVauyJn+Yf1NduoPk=",
+            "version": "1.3.45",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.45.tgz",
+            "integrity": "sha1-RYrBscXHYM6IEaFtK/vZfsMLr7g=",
             "dev": true
         },
         "elegant-spinner": {
@@ -4926,8 +5004,9 @@
             "version": "0.1.12",
             "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
             "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+            "dev": true,
             "requires": {
-                "iconv-lite": "0.4.21"
+                "iconv-lite": "0.4.23"
             }
         },
         "end-of-stream": {
@@ -5150,7 +5229,7 @@
             "requires": {
                 "ajv": "5.5.2",
                 "babel-code-frame": "6.26.0",
-                "chalk": "2.4.0",
+                "chalk": "2.4.1",
                 "concat-stream": "1.6.0",
                 "cross-spawn": "5.1.0",
                 "debug": "3.1.0",
@@ -5163,15 +5242,15 @@
                 "file-entry-cache": "2.0.0",
                 "functional-red-black-tree": "1.0.1",
                 "glob": "7.1.2",
-                "globals": "11.4.0",
-                "ignore": "3.3.7",
+                "globals": "11.5.0",
+                "ignore": "3.3.8",
                 "imurmurhash": "0.1.4",
                 "inquirer": "3.3.0",
                 "is-resolvable": "1.1.0",
                 "js-yaml": "3.11.0",
                 "json-stable-stringify-without-jsonify": "1.0.1",
                 "levn": "0.3.0",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "minimatch": "3.0.4",
                 "mkdirp": "0.5.1",
                 "natural-compare": "1.4.0",
@@ -5204,9 +5283,9 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
@@ -5221,9 +5300,9 @@
                     "dev": true
                 },
                 "globals": {
-                    "version": "11.4.0",
-                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
-                    "integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA==",
+                    "version": "11.5.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.5.0.tgz",
+                    "integrity": "sha512-hYyf+kI8dm3nORsiiXUQigOU62hDLfJ9G01uyGMxhc6BKsircrUhC4uJPQPUSuq2GrTmiiEt7ewxlMdBewfmKQ==",
                     "dev": true
                 },
                 "has-flag": {
@@ -5383,7 +5462,7 @@
                 "eslint-import-resolver-node": "0.3.2",
                 "eslint-module-utils": "2.2.0",
                 "has": "1.0.1",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "minimatch": "3.0.4",
                 "read-pkg-up": "2.0.0",
                 "resolve": "1.7.1"
@@ -5549,9 +5628,9 @@
             }
         },
         "eventemitter3": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.0.1.tgz",
-            "integrity": "sha512-QOCPu979MMWX9XNlfRZoin+Wm+bK1SP7vv3NGUniYwuSJK/+cPA10blMaeRgzg31RvoSFk6FsCDVa4vNryBTGA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+            "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
             "dev": true
         },
         "events": {
@@ -5576,7 +5655,7 @@
             "dev": true,
             "requires": {
                 "md5.js": "1.3.4",
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "exec-sh": {
@@ -5665,18 +5744,18 @@
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
-                "fill-range": "2.2.3"
+                "fill-range": "2.2.4"
             },
             "dependencies": {
                 "fill-range": {
-                    "version": "2.2.3",
-                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-                    "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+                    "version": "2.2.4",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+                    "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
                     "dev": true,
                     "requires": {
                         "is-number": "2.1.0",
                         "isobject": "2.1.0",
-                        "randomatic": "1.1.7",
+                        "randomatic": "3.0.0",
                         "repeat-element": "1.1.2",
                         "repeat-string": "1.6.1"
                     }
@@ -5793,6 +5872,12 @@
                     "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
                     "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
                     "dev": true
+                },
+                "safe-buffer": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+                    "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+                    "dev": true
                 }
             }
         },
@@ -5830,7 +5915,7 @@
             "dev": true,
             "requires": {
                 "chardet": "0.4.2",
-                "iconv-lite": "0.4.21",
+                "iconv-lite": "0.4.23",
                 "tmp": "0.0.33"
             },
             "dependencies": {
@@ -5969,6 +6054,19 @@
             "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
             "dev": true
         },
+        "fast-glob": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.1.tgz",
+            "integrity": "sha512-wSyW1TBK3ia5V+te0rGPXudeMHoUQW6O5Y9oATiaGhpENmEifPDlOdhpsnlj5HoG6ttIvGiY1DdCmI9X2xGMhg==",
+            "dev": true,
+            "requires": {
+                "@mrmlnc/readdir-enhanced": "2.2.1",
+                "glob-parent": "3.1.0",
+                "is-glob": "4.0.0",
+                "merge2": "1.2.2",
+                "micromatch": "3.1.10"
+            }
+        },
         "fast-json-stable-stringify": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -6009,6 +6107,7 @@
             "version": "0.8.16",
             "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
             "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+            "dev": true,
             "requires": {
                 "core-js": "1.2.7",
                 "isomorphic-fetch": "2.2.1",
@@ -6016,13 +6115,14 @@
                 "object-assign": "4.1.1",
                 "promise": "7.3.1",
                 "setimmediate": "1.0.5",
-                "ua-parser-js": "0.7.17"
+                "ua-parser-js": "0.7.18"
             },
             "dependencies": {
                 "core-js": {
                     "version": "1.2.7",
                     "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-                    "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+                    "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+                    "dev": true
                 }
             }
         },
@@ -6127,7 +6227,7 @@
             "dev": true,
             "requires": {
                 "commondir": "1.0.1",
-                "make-dir": "1.2.0",
+                "make-dir": "1.3.0",
                 "pkg-dir": "2.0.0"
             }
         },
@@ -6171,9 +6271,9 @@
             "dev": true
         },
         "flow-parser": {
-            "version": "0.70.0",
-            "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.70.0.tgz",
-            "integrity": "sha512-gGdyVUZWswG5jcINrVDHd3RY4nJptBTAx9mR9thGsrGGmAUR7omgJXQSpR+fXrLtxSTAea3HpAZNU/yzRJc2Cg==",
+            "version": "0.72.0",
+            "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.72.0.tgz",
+            "integrity": "sha512-kFaDtviKlD/rHi6NRp42KTbnPgz/nKcWUJQhqDnLDeKA8uGcRVSy0YlQjaf9M3pFo5PgC3SNFnCPpQGLtHjH2w==",
             "dev": true
         },
         "flush-write-stream": {
@@ -6281,16 +6381,6 @@
                 "universalify": "0.1.1"
             }
         },
-        "fs-minipass": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-            "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "minipass": "2.2.4"
-            }
-        },
         "fs-readdir-recursive": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
@@ -6316,9 +6406,9 @@
             "dev": true
         },
         "fsevents": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.0.tgz",
-            "integrity": "sha512-ROrBIbmw4ulxmQTwYAAGyN/0xgIOAFd6gX/K3F1aGLP/K5KxkubrlGISMV5EEWEB7qtiEdE0HpaqvMMHR+Ib6w==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.3.tgz",
+            "integrity": "sha512-X+57O5YkDTiEQGiw8i7wYc2nQgweIekqkepI8Q3y4wVlurgBt2SuwxTeYUYMZIGpLZH3r/TsMjczCMXE5ZOt7Q==",
             "dev": true,
             "optional": true,
             "requires": {
@@ -6327,222 +6417,122 @@
             },
             "dependencies": {
                 "abbrev": {
-                    "version": "1.1.0",
-                    "bundled": true
-                },
-                "ajv": {
-                    "version": "4.11.8",
+                    "version": "1.1.1",
                     "bundled": true,
-                    "requires": {
-                        "co": "4.6.0",
-                        "json-stable-stringify": "1.0.1"
-                    }
+                    "dev": true,
+                    "optional": true
                 },
                 "ansi-regex": {
                     "version": "2.1.1",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true
                 },
                 "aproba": {
-                    "version": "1.1.1",
-                    "bundled": true
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
                 },
                 "are-we-there-yet": {
                     "version": "1.1.4",
                     "bundled": true,
-                    "requires": {
-                        "delegates": "1.0.0",
-                        "readable-stream": "2.2.9"
-                    }
-                },
-                "asn1": {
-                    "version": "0.2.3",
-                    "bundled": true
-                },
-                "assert-plus": {
-                    "version": "0.2.0",
-                    "bundled": true
-                },
-                "asynckit": {
-                    "version": "0.4.0",
-                    "bundled": true
-                },
-                "aws-sign2": {
-                    "version": "0.6.0",
-                    "bundled": true
-                },
-                "aws4": {
-                    "version": "1.6.0",
-                    "bundled": true
-                },
-                "balanced-match": {
-                    "version": "0.4.2",
-                    "bundled": true
-                },
-                "bcrypt-pbkdf": {
-                    "version": "1.0.1",
-                    "bundled": true,
+                    "dev": true,
                     "optional": true,
                     "requires": {
-                        "tweetnacl": "0.14.5"
+                        "delegates": "1.0.0",
+                        "readable-stream": "2.3.6"
                     }
                 },
-                "block-stream": {
-                    "version": "0.0.9",
+                "balanced-match": {
+                    "version": "1.0.0",
                     "bundled": true,
-                    "requires": {
-                        "inherits": "2.0.3"
-                    }
-                },
-                "boom": {
-                    "version": "2.10.1",
-                    "bundled": true,
-                    "requires": {
-                        "hoek": "2.16.3"
-                    }
+                    "dev": true
                 },
                 "brace-expansion": {
-                    "version": "1.1.7",
+                    "version": "1.1.11",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
-                        "balanced-match": "0.4.2",
+                        "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
-                "buffer-shims": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "caseless": {
-                    "version": "0.12.0",
-                    "bundled": true
-                },
-                "co": {
-                    "version": "4.6.0",
-                    "bundled": true
+                "chownr": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
                 },
                 "code-point-at": {
                     "version": "1.1.0",
-                    "bundled": true
-                },
-                "combined-stream": {
-                    "version": "1.0.5",
                     "bundled": true,
-                    "requires": {
-                        "delayed-stream": "1.0.0"
-                    }
+                    "dev": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
-                    "bundled": true
-                },
-                "cryptiles": {
-                    "version": "2.0.5",
                     "bundled": true,
-                    "requires": {
-                        "boom": "2.10.1"
-                    }
-                },
-                "dashdash": {
-                    "version": "1.14.1",
-                    "bundled": true,
-                    "requires": {
-                        "assert-plus": "1.0.0"
-                    },
-                    "dependencies": {
-                        "assert-plus": {
-                            "version": "1.0.0",
-                            "bundled": true
-                        }
-                    }
+                    "dev": true,
+                    "optional": true
                 },
                 "debug": {
-                    "version": "2.6.8",
+                    "version": "2.6.9",
                     "bundled": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
                 },
                 "deep-extend": {
                     "version": "0.4.2",
-                    "bundled": true
-                },
-                "delayed-stream": {
-                    "version": "1.0.0",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
                 },
                 "delegates": {
                     "version": "1.0.0",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
                 },
                 "detect-libc": {
-                    "version": "1.0.2",
-                    "bundled": true
-                },
-                "ecc-jsbn": {
-                    "version": "0.1.1",
+                    "version": "1.0.3",
                     "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "fs-minipass": {
+                    "version": "1.2.5",
+                    "bundled": true,
+                    "dev": true,
                     "optional": true,
                     "requires": {
-                        "jsbn": "0.1.1"
-                    }
-                },
-                "extend": {
-                    "version": "3.0.1",
-                    "bundled": true
-                },
-                "extsprintf": {
-                    "version": "1.0.2",
-                    "bundled": true
-                },
-                "forever-agent": {
-                    "version": "0.6.1",
-                    "bundled": true
-                },
-                "form-data": {
-                    "version": "2.1.4",
-                    "bundled": true,
-                    "requires": {
-                        "asynckit": "0.4.0",
-                        "combined-stream": "1.0.5",
-                        "mime-types": "2.1.15"
+                        "minipass": "2.2.4"
                     }
                 },
                 "fs.realpath": {
                     "version": "1.0.0",
-                    "bundled": true
-                },
-                "fstream": {
-                    "version": "1.0.11",
                     "bundled": true,
-                    "requires": {
-                        "graceful-fs": "4.1.11",
-                        "inherits": "2.0.3",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.6.1"
-                    }
-                },
-                "fstream-ignore": {
-                    "version": "1.0.5",
-                    "bundled": true,
-                    "requires": {
-                        "fstream": "1.0.11",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4"
-                    }
+                    "dev": true,
+                    "optional": true
                 },
                 "gauge": {
                     "version": "2.7.4",
                     "bundled": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
-                        "aproba": "1.1.1",
+                        "aproba": "1.2.0",
                         "console-control-strings": "1.1.0",
                         "has-unicode": "2.0.1",
                         "object-assign": "4.1.1",
@@ -6552,22 +6542,11 @@
                         "wide-align": "1.1.2"
                     }
                 },
-                "getpass": {
-                    "version": "0.1.7",
-                    "bundled": true,
-                    "requires": {
-                        "assert-plus": "1.0.0"
-                    },
-                    "dependencies": {
-                        "assert-plus": {
-                            "version": "1.0.0",
-                            "bundled": true
-                        }
-                    }
-                },
                 "glob": {
                     "version": "7.1.2",
                     "bundled": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "fs.realpath": "1.0.0",
                         "inflight": "1.0.6",
@@ -6577,52 +6556,35 @@
                         "path-is-absolute": "1.0.1"
                     }
                 },
-                "graceful-fs": {
-                    "version": "4.1.11",
-                    "bundled": true
-                },
-                "har-schema": {
-                    "version": "1.0.5",
-                    "bundled": true
-                },
-                "har-validator": {
-                    "version": "4.2.1",
-                    "bundled": true,
-                    "requires": {
-                        "ajv": "4.11.8",
-                        "har-schema": "1.0.5"
-                    }
-                },
                 "has-unicode": {
                     "version": "2.0.1",
-                    "bundled": true
-                },
-                "hawk": {
-                    "version": "3.1.3",
                     "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "iconv-lite": {
+                    "version": "0.4.21",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
-                        "boom": "2.10.1",
-                        "cryptiles": "2.0.5",
-                        "hoek": "2.16.3",
-                        "sntp": "1.0.9"
+                        "safer-buffer": "2.1.2"
                     }
                 },
-                "hoek": {
-                    "version": "2.16.3",
-                    "bundled": true
-                },
-                "http-signature": {
-                    "version": "1.1.1",
+                "ignore-walk": {
+                    "version": "3.0.1",
                     "bundled": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
-                        "assert-plus": "0.2.0",
-                        "jsprim": "1.4.0",
-                        "sshpk": "1.13.0"
+                        "minimatch": "3.0.4"
                     }
                 },
                 "inflight": {
                     "version": "1.0.6",
                     "bundled": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "once": "1.4.0",
                         "wrappy": "1.0.2"
@@ -6630,123 +6592,134 @@
                 },
                 "inherits": {
                     "version": "2.0.3",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true
                 },
                 "ini": {
-                    "version": "1.3.4",
-                    "bundled": true
+                    "version": "1.3.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "number-is-nan": "1.0.1"
                     }
                 },
-                "is-typedarray": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
                 "isarray": {
                     "version": "1.0.0",
-                    "bundled": true
-                },
-                "isstream": {
-                    "version": "0.1.2",
-                    "bundled": true
-                },
-                "jodid25519": {
-                    "version": "1.0.2",
                     "bundled": true,
-                    "optional": true,
-                    "requires": {
-                        "jsbn": "0.1.1"
-                    }
-                },
-                "jsbn": {
-                    "version": "0.1.1",
-                    "bundled": true,
+                    "dev": true,
                     "optional": true
-                },
-                "json-schema": {
-                    "version": "0.2.3",
-                    "bundled": true
-                },
-                "json-stable-stringify": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "requires": {
-                        "jsonify": "0.0.0"
-                    }
-                },
-                "json-stringify-safe": {
-                    "version": "5.0.1",
-                    "bundled": true
-                },
-                "jsonify": {
-                    "version": "0.0.0",
-                    "bundled": true
-                },
-                "jsprim": {
-                    "version": "1.4.0",
-                    "bundled": true,
-                    "requires": {
-                        "assert-plus": "1.0.0",
-                        "extsprintf": "1.0.2",
-                        "json-schema": "0.2.3",
-                        "verror": "1.3.6"
-                    },
-                    "dependencies": {
-                        "assert-plus": {
-                            "version": "1.0.0",
-                            "bundled": true
-                        }
-                    }
-                },
-                "mime-db": {
-                    "version": "1.27.0",
-                    "bundled": true
-                },
-                "mime-types": {
-                    "version": "2.1.15",
-                    "bundled": true,
-                    "requires": {
-                        "mime-db": "1.27.0"
-                    }
                 },
                 "minimatch": {
                     "version": "3.0.4",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
-                        "brace-expansion": "1.1.7"
+                        "brace-expansion": "1.1.11"
                     }
                 },
                 "minimist": {
                     "version": "0.0.8",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true
+                },
+                "minipass": {
+                    "version": "2.2.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.1",
+                        "yallist": "3.0.2"
+                    }
+                },
+                "minizlib": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "minipass": "2.2.4"
+                    }
                 },
                 "mkdirp": {
                     "version": "0.5.1",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
                 },
                 "ms": {
                     "version": "2.0.0",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "needle": {
+                    "version": "2.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "debug": "2.6.9",
+                        "iconv-lite": "0.4.21",
+                        "sax": "1.2.4"
+                    }
+                },
+                "node-pre-gyp": {
+                    "version": "0.9.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "detect-libc": "1.0.3",
+                        "mkdirp": "0.5.1",
+                        "needle": "2.2.0",
+                        "nopt": "4.0.1",
+                        "npm-packlist": "1.1.10",
+                        "npmlog": "4.1.2",
+                        "rc": "1.2.6",
+                        "rimraf": "2.6.2",
+                        "semver": "5.5.0",
+                        "tar": "4.4.1"
+                    }
                 },
                 "nopt": {
                     "version": "4.0.1",
                     "bundled": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
-                        "abbrev": "1.1.0",
-                        "osenv": "0.1.4"
+                        "abbrev": "1.1.1",
+                        "osenv": "0.1.5"
+                    }
+                },
+                "npm-bundled": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "npm-packlist": {
+                    "version": "1.1.10",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "ignore-walk": "3.0.1",
+                        "npm-bundled": "1.0.3"
                     }
                 },
                 "npmlog": {
-                    "version": "4.1.0",
+                    "version": "4.1.2",
                     "bundled": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "are-we-there-yet": "1.1.4",
                         "console-control-strings": "1.1.0",
@@ -6756,34 +6729,40 @@
                 },
                 "number-is-nan": {
                     "version": "1.0.1",
-                    "bundled": true
-                },
-                "oauth-sign": {
-                    "version": "0.8.2",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
                 },
                 "once": {
                     "version": "1.4.0",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "wrappy": "1.0.2"
                     }
                 },
                 "os-homedir": {
                     "version": "1.0.2",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
                 },
                 "os-tmpdir": {
                     "version": "1.0.2",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
                 },
                 "osenv": {
-                    "version": "0.1.4",
+                    "version": "0.1.5",
                     "bundled": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "os-homedir": "1.0.2",
                         "os-tmpdir": "1.0.2"
@@ -6791,135 +6770,99 @@
                 },
                 "path-is-absolute": {
                     "version": "1.0.1",
-                    "bundled": true
-                },
-                "performance-now": {
-                    "version": "0.2.0",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
                 },
                 "process-nextick-args": {
-                    "version": "1.0.7",
-                    "bundled": true
-                },
-                "punycode": {
-                    "version": "1.4.1",
-                    "bundled": true
-                },
-                "qs": {
-                    "version": "6.4.0",
-                    "bundled": true
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
                 },
                 "rc": {
-                    "version": "1.2.1",
+                    "version": "1.2.6",
                     "bundled": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "deep-extend": "0.4.2",
-                        "ini": "1.3.4",
+                        "ini": "1.3.5",
                         "minimist": "1.2.0",
                         "strip-json-comments": "2.0.1"
                     },
                     "dependencies": {
                         "minimist": {
                             "version": "1.2.0",
-                            "bundled": true
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
                         }
                     }
                 },
                 "readable-stream": {
-                    "version": "2.2.9",
+                    "version": "2.3.6",
                     "bundled": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
-                        "buffer-shims": "1.0.0",
                         "core-util-is": "1.0.2",
                         "inherits": "2.0.3",
                         "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "string_decoder": "1.0.1",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.1.1",
                         "util-deprecate": "1.0.2"
                     }
                 },
-                "request": {
-                    "version": "2.81.0",
-                    "bundled": true,
-                    "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.6.0",
-                        "caseless": "0.12.0",
-                        "combined-stream": "1.0.5",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.4",
-                        "har-validator": "4.2.1",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.15",
-                        "oauth-sign": "0.8.2",
-                        "performance-now": "0.2.0",
-                        "qs": "6.4.0",
-                        "safe-buffer": "5.0.1",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.2",
-                        "tunnel-agent": "0.6.0",
-                        "uuid": "3.0.1"
-                    }
-                },
                 "rimraf": {
-                    "version": "2.6.1",
+                    "version": "2.6.2",
                     "bundled": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "glob": "7.1.2"
                     }
                 },
                 "safe-buffer": {
-                    "version": "5.0.1",
-                    "bundled": true
+                    "version": "5.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "safer-buffer": {
+                    "version": "2.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "sax": {
+                    "version": "1.2.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
                 },
                 "semver": {
-                    "version": "5.3.0",
-                    "bundled": true
+                    "version": "5.5.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
                 },
                 "set-blocking": {
                     "version": "2.0.0",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
                 },
                 "signal-exit": {
                     "version": "3.0.2",
-                    "bundled": true
-                },
-                "sntp": {
-                    "version": "1.0.9",
                     "bundled": true,
-                    "requires": {
-                        "hoek": "2.16.3"
-                    }
-                },
-                "sshpk": {
-                    "version": "1.13.0",
-                    "bundled": true,
-                    "requires": {
-                        "asn1": "0.2.3",
-                        "assert-plus": "1.0.0",
-                        "bcrypt-pbkdf": "1.0.1",
-                        "dashdash": "1.14.1",
-                        "ecc-jsbn": "0.1.1",
-                        "getpass": "0.1.7",
-                        "jodid25519": "1.0.2",
-                        "jsbn": "0.1.1",
-                        "tweetnacl": "0.14.5"
-                    },
-                    "dependencies": {
-                        "assert-plus": {
-                            "version": "1.0.0",
-                            "bundled": true
-                        }
-                    }
+                    "dev": true,
+                    "optional": true
                 },
                 "string-width": {
                     "version": "1.0.2",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "code-point-at": "1.1.0",
                         "is-fullwidth-code-point": "1.0.0",
@@ -6927,98 +6870,67 @@
                     }
                 },
                 "string_decoder": {
-                    "version": "1.0.1",
+                    "version": "1.1.1",
                     "bundled": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
-                        "safe-buffer": "5.0.1"
+                        "safe-buffer": "5.1.1"
                     }
-                },
-                "stringstream": {
-                    "version": "0.0.5",
-                    "bundled": true
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "ansi-regex": "2.1.1"
                     }
                 },
                 "strip-json-comments": {
                     "version": "2.0.1",
-                    "bundled": true
-                },
-                "tar": {
-                    "version": "2.2.1",
                     "bundled": true,
-                    "requires": {
-                        "block-stream": "0.0.9",
-                        "fstream": "1.0.11",
-                        "inherits": "2.0.3"
-                    }
-                },
-                "tar-pack": {
-                    "version": "3.4.0",
-                    "bundled": true,
-                    "requires": {
-                        "debug": "2.6.8",
-                        "fstream": "1.0.11",
-                        "fstream-ignore": "1.0.5",
-                        "once": "1.4.0",
-                        "readable-stream": "2.2.9",
-                        "rimraf": "2.6.1",
-                        "tar": "2.2.1",
-                        "uid-number": "0.0.6"
-                    }
-                },
-                "tough-cookie": {
-                    "version": "2.3.2",
-                    "bundled": true,
-                    "requires": {
-                        "punycode": "1.4.1"
-                    }
-                },
-                "tunnel-agent": {
-                    "version": "0.6.0",
-                    "bundled": true,
-                    "requires": {
-                        "safe-buffer": "5.0.1"
-                    }
-                },
-                "tweetnacl": {
-                    "version": "0.14.5",
-                    "bundled": true,
+                    "dev": true,
                     "optional": true
                 },
-                "uid-number": {
-                    "version": "0.0.6",
-                    "bundled": true
+                "tar": {
+                    "version": "4.4.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "chownr": "1.0.1",
+                        "fs-minipass": "1.2.5",
+                        "minipass": "2.2.4",
+                        "minizlib": "1.1.0",
+                        "mkdirp": "0.5.1",
+                        "safe-buffer": "5.1.1",
+                        "yallist": "3.0.2"
+                    }
                 },
                 "util-deprecate": {
                     "version": "1.0.2",
-                    "bundled": true
-                },
-                "uuid": {
-                    "version": "3.0.1",
-                    "bundled": true
-                },
-                "verror": {
-                    "version": "1.3.6",
                     "bundled": true,
-                    "requires": {
-                        "extsprintf": "1.0.2"
-                    }
+                    "dev": true,
+                    "optional": true
                 },
                 "wide-align": {
                     "version": "1.1.2",
                     "bundled": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "string-width": "1.0.2"
                     }
                 },
                 "wrappy": {
                     "version": "1.0.2",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true
+                },
+                "yallist": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true
                 }
             }
         },
@@ -7033,23 +6945,6 @@
             "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
             "dev": true
-        },
-        "gauge": {
-            "version": "2.7.4",
-            "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-            "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "aproba": "1.2.0",
-                "console-control-strings": "1.1.0",
-                "has-unicode": "2.0.1",
-                "object-assign": "4.1.1",
-                "signal-exit": "3.0.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wide-align": "1.1.2"
-            }
         },
         "get-caller-file": {
             "version": "1.0.2",
@@ -7102,7 +6997,7 @@
                     "integrity": "sha1-LSFgx3iAMuTdbL4lAvH5osj2zeQ=",
                     "dev": true,
                     "requires": {
-                        "lodash": "4.17.5"
+                        "lodash": "4.17.10"
                     }
                 }
             }
@@ -7150,7 +7045,7 @@
                         "lowercase-keys": "1.0.1",
                         "p-cancelable": "0.3.0",
                         "p-timeout": "1.2.1",
-                        "safe-buffer": "5.1.1",
+                        "safe-buffer": "5.1.2",
                         "timed-out": "4.0.1",
                         "url-parse-lax": "1.0.0",
                         "url-to-options": "1.0.1"
@@ -7462,6 +7357,12 @@
                 }
             }
         },
+        "glob-to-regexp": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+            "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+            "dev": true
+        },
         "global-dirs": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
@@ -7530,9 +7431,9 @@
             }
         },
         "got": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/got/-/got-8.3.0.tgz",
-            "integrity": "sha512-kBNy/S2CGwrYgDSec5KTWGKUvupwkkTVAjIsVFF2shXO13xpZdFP4d4kxa//CLX2tN/rV0aYwK8vY6UKWGn2vQ==",
+            "version": "8.3.1",
+            "resolved": "https://registry.npmjs.org/got/-/got-8.3.1.tgz",
+            "integrity": "sha512-tiLX+bnYm5A56T5N/n9Xo89vMaO1mrS9qoDqj3u/anVooqGozvY/HbXzEpDfbNeKsHCBpK40gSbz8wGYSp3i1w==",
             "dev": true,
             "requires": {
                 "@sindresorhus/is": "0.7.0",
@@ -7548,7 +7449,7 @@
                 "p-cancelable": "0.4.1",
                 "p-timeout": "2.0.1",
                 "pify": "3.0.0",
-                "safe-buffer": "5.1.1",
+                "safe-buffer": "5.1.2",
                 "timed-out": "4.0.1",
                 "url-parse-lax": "3.0.0",
                 "url-to-options": "1.0.1"
@@ -7566,7 +7467,7 @@
             "integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
             "dev": true,
             "requires": {
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
             }
         },
         "growly": {
@@ -7721,6 +7622,12 @@
             "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
             "dev": true
         },
+        "has-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+            "dev": true
+        },
         "has-to-string-tag-x": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
@@ -7729,13 +7636,6 @@
             "requires": {
                 "has-symbol-support-x": "1.4.2"
             }
-        },
-        "has-unicode": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-            "dev": true,
-            "optional": true
         },
         "has-value": {
             "version": "1.0.0",
@@ -7776,7 +7676,7 @@
             "dev": true,
             "requires": {
                 "inherits": "2.0.3",
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "hash.js": {
@@ -7818,8 +7718,8 @@
                 "kebab-case": "1.0.0",
                 "property-information": "3.2.0",
                 "space-separated-tokens": "1.1.2",
-                "stringify-entities": "1.3.1",
-                "unist-util-is": "2.1.1",
+                "stringify-entities": "1.3.2",
+                "unist-util-is": "2.1.2",
                 "xtend": "4.0.1"
             }
         },
@@ -7940,7 +7840,7 @@
                 "he": "1.1.1",
                 "param-case": "2.1.1",
                 "relateurl": "0.2.7",
-                "uglify-js": "3.3.22"
+                "uglify-js": "3.3.24"
             },
             "dependencies": {
                 "source-map": {
@@ -7950,9 +7850,9 @@
                     "dev": true
                 },
                 "uglify-js": {
-                    "version": "3.3.22",
-                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.22.tgz",
-                    "integrity": "sha512-tqw96rL6/BG+7LM5VItdhDjTQmL5zG/I0b2RqWytlgeHe2eydZHuBHdA9vuGpCDhH/ZskNGcqDhivoR2xt8RIw==",
+                    "version": "3.3.24",
+                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.24.tgz",
+                    "integrity": "sha512-hS7+TDiqIqvWScCcKRybCQzmMnEzJ4ryl9ErRmW4GFyG48p0/dKZiy/5mVLbsFzU8CCnCgQdxMiJzZythvLzCg==",
                     "dev": true,
                     "requires": {
                         "commander": "2.15.1",
@@ -7976,9 +7876,9 @@
                 "bluebird": "3.5.0",
                 "html-minifier": "3.5.15",
                 "loader-utils": "0.2.17",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "pretty-error": "2.1.1",
-                "toposort": "1.0.6"
+                "toposort": "1.0.7"
             },
             "dependencies": {
                 "loader-utils": {
@@ -8067,9 +7967,9 @@
             }
         },
         "http-parser-js": {
-            "version": "0.4.11",
-            "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.11.tgz",
-            "integrity": "sha512-QCR5O2AjjMW8Mo4HyI1ctFcv+O99j/0g367V3YoVnrNw5hkDvAWZD0lWGcc+F4yN3V55USPCVix4efb75HxFfA==",
+            "version": "0.4.12",
+            "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.12.tgz",
+            "integrity": "sha1-uc+/Sizybw/DSxDKFImid3HjR08=",
             "dev": true
         },
         "http-proxy": {
@@ -8078,7 +7978,7 @@
             "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
             "dev": true,
             "requires": {
-                "eventemitter3": "3.0.1",
+                "eventemitter3": "3.1.0",
                 "follow-redirects": "1.4.1",
                 "requires-port": "1.0.0"
             }
@@ -8091,7 +7991,7 @@
             "requires": {
                 "http-proxy": "1.17.0",
                 "is-glob": "4.0.0",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "micromatch": "3.1.10"
             }
         },
@@ -8156,9 +8056,10 @@
             }
         },
         "iconv-lite": {
-            "version": "0.4.21",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
-            "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
+            "version": "0.4.23",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+            "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+            "dev": true,
             "requires": {
                 "safer-buffer": "2.1.2"
             }
@@ -8175,7 +8076,7 @@
             "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
             "dev": true,
             "requires": {
-                "postcss": "6.0.21"
+                "postcss": "6.0.22"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -8188,9 +8089,9 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
@@ -8205,12 +8106,12 @@
                     "dev": true
                 },
                 "postcss": {
-                    "version": "6.0.21",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
-                    "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
+                    "version": "6.0.22",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
+                    "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.4.0",
+                        "chalk": "2.4.1",
                         "source-map": "0.6.1",
                         "supports-color": "5.4.0"
                     }
@@ -8245,20 +8146,10 @@
             "dev": true
         },
         "ignore": {
-            "version": "3.3.7",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-            "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+            "version": "3.3.8",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
+            "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg==",
             "dev": true
-        },
-        "ignore-walk": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-            "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "minimatch": "3.0.4"
-            }
         },
         "import-local": {
             "version": "1.0.0",
@@ -8326,12 +8217,12 @@
             "dev": true,
             "requires": {
                 "ansi-escapes": "3.1.0",
-                "chalk": "2.4.0",
+                "chalk": "2.4.1",
                 "cli-cursor": "2.1.0",
                 "cli-width": "2.2.0",
                 "external-editor": "2.2.0",
                 "figures": "2.0.0",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "mute-stream": "0.0.7",
                 "run-async": "2.3.0",
                 "rx-lite": "4.0.8",
@@ -8363,9 +8254,9 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
@@ -8397,12 +8288,6 @@
                     "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
                     "dev": true
                 },
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                    "dev": true
-                },
                 "onetime": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
@@ -8420,16 +8305,6 @@
                     "requires": {
                         "onetime": "2.0.1",
                         "signal-exit": "3.0.2"
-                    }
-                },
-                "string-width": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-                    "dev": true,
-                    "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -8887,7 +8762,8 @@
         "is-stream": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+            "dev": true
         },
         "is-svg": {
             "version": "2.1.0",
@@ -8944,9 +8820,9 @@
             "dev": true
         },
         "is-word-character": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.1.tgz",
-            "integrity": "sha1-WgP6HqkazopusMfNdw64bWXIvvs=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.2.tgz",
+            "integrity": "sha512-T3FlsX8rCHAH8e7RE7PfOPZVFQlcV3XRF9eOOBQ1uf70OxO7CjjSOjeImMPCADBdYWcStAbVbYvJ1m2D3tb+EA==",
             "dev": true
         },
         "is-wsl": {
@@ -8959,6 +8835,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "dev": true
+        },
+        "isbinaryfile": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.2.tgz",
+            "integrity": "sha1-Sj6XTsDLqQBNP8bN5yCeppNopiE=",
             "dev": true
         },
         "isexe": {
@@ -8977,6 +8859,7 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
             "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+            "dev": true,
             "requires": {
                 "node-fetch": "1.7.3",
                 "whatwg-fetch": "2.0.4"
@@ -9189,9 +9072,9 @@
                     "dev": true
                 },
                 "chalk": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
@@ -9200,9 +9083,9 @@
                     }
                 },
                 "cliui": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
-                    "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+                    "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
                     "dev": true,
                     "requires": {
                         "string-width": "2.1.1",
@@ -9240,12 +9123,6 @@
                     "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
                     "dev": true
                 },
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                    "dev": true
-                },
                 "is-glob": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
@@ -9262,7 +9139,7 @@
                     "dev": true,
                     "requires": {
                         "ansi-escapes": "3.1.0",
-                        "chalk": "2.4.0",
+                        "chalk": "2.4.1",
                         "exit": "0.1.2",
                         "glob": "7.1.2",
                         "graceful-fs": "4.1.11",
@@ -9318,16 +9195,6 @@
                         "regex-cache": "0.4.4"
                     }
                 },
-                "string-width": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-                    "dev": true,
-                    "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
-                    }
-                },
                 "strip-ansi": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -9352,7 +9219,7 @@
                     "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
                     "dev": true,
                     "requires": {
-                        "cliui": "4.0.0",
+                        "cliui": "4.1.0",
                         "decamelize": "1.2.0",
                         "find-up": "2.1.0",
                         "get-caller-file": "1.0.2",
@@ -9392,7 +9259,7 @@
             "integrity": "sha512-KSg3EOToCgkX+lIvenKY7J8s426h6ahXxaUFJxvGoEk0562Z6inWj1TnKoGycTASwiLD+6kSYFALcjdosq9KIQ==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.0",
+                "chalk": "2.4.1",
                 "glob": "7.1.2",
                 "jest-environment-jsdom": "22.4.3",
                 "jest-environment-node": "22.4.3",
@@ -9415,9 +9282,9 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
@@ -9448,7 +9315,7 @@
             "integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.0",
+                "chalk": "2.4.1",
                 "diff": "3.5.0",
                 "jest-get-type": "22.4.3",
                 "pretty-format": "22.4.3"
@@ -9464,9 +9331,9 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
@@ -9514,7 +9381,7 @@
             "requires": {
                 "jest-mock": "22.4.3",
                 "jest-util": "22.4.3",
-                "jsdom": "11.8.0"
+                "jsdom": "11.10.0"
             }
         },
         "jest-environment-node": {
@@ -9545,7 +9412,7 @@
                 "jest-serializer": "22.4.3",
                 "jest-worker": "22.4.3",
                 "micromatch": "2.3.11",
-                "sane": "2.5.0"
+                "sane": "2.5.2"
             },
             "dependencies": {
                 "arr-diff": {
@@ -9636,7 +9503,7 @@
             "integrity": "sha512-yZCPCJUcEY6R5KJB/VReo1AYI2b+5Ky+C+JA1v34jndJsRcLpU4IZX4rFJn7yDTtdNbO/nNqg+3SDIPNH2ecnw==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.0",
+                "chalk": "2.4.1",
                 "co": "4.6.0",
                 "expect": "22.4.3",
                 "graceful-fs": "4.1.11",
@@ -9646,7 +9513,7 @@
                 "jest-message-util": "22.4.3",
                 "jest-snapshot": "22.4.3",
                 "jest-util": "22.4.3",
-                "source-map-support": "0.5.4"
+                "source-map-support": "0.5.5"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9659,9 +9526,9 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
@@ -9682,11 +9549,12 @@
                     "dev": true
                 },
                 "source-map-support": {
-                    "version": "0.5.4",
-                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.4.tgz",
-                    "integrity": "sha512-PETSPG6BjY1AHs2t64vS2aqAgu6dMIMXJULWFBGbh2Gr8nVLbCFDo6i/RMMvviIQ2h1Z8+5gQhVKSn2je9nmdg==",
+                    "version": "0.5.5",
+                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.5.tgz",
+                    "integrity": "sha512-mR7/Nd5l1z6g99010shcXJiNEaf3fEtmLhRB/sBcQVJGodcHCULPp2y4Sfa43Kv2zq7T+Izmfp/WHCR6dYkQCA==",
                     "dev": true,
                     "requires": {
+                        "buffer-from": "1.0.0",
                         "source-map": "0.6.1"
                     }
                 },
@@ -9716,7 +9584,7 @@
             "integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.0",
+                "chalk": "2.4.1",
                 "jest-get-type": "22.4.3",
                 "pretty-format": "22.4.3"
             },
@@ -9731,9 +9599,9 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
@@ -9765,7 +9633,7 @@
             "dev": true,
             "requires": {
                 "@babel/code-frame": "7.0.0-beta.44",
-                "chalk": "2.4.0",
+                "chalk": "2.4.1",
                 "micromatch": "2.3.11",
                 "slash": "1.0.0",
                 "stack-utils": "1.0.1"
@@ -9807,9 +9675,9 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
@@ -9907,7 +9775,7 @@
             "dev": true,
             "requires": {
                 "browser-resolve": "1.11.2",
-                "chalk": "2.4.0"
+                "chalk": "2.4.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9920,9 +9788,9 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
@@ -9984,7 +9852,7 @@
                 "babel-core": "6.26.0",
                 "babel-jest": "22.4.3",
                 "babel-plugin-istanbul": "4.1.6",
-                "chalk": "2.4.0",
+                "chalk": "2.4.1",
                 "convert-source-map": "1.5.1",
                 "exit": "0.1.2",
                 "graceful-fs": "4.1.11",
@@ -10051,9 +9919,9 @@
                     "dev": true
                 },
                 "chalk": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
@@ -10062,9 +9930,9 @@
                     }
                 },
                 "cliui": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
-                    "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+                    "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
                     "dev": true,
                     "requires": {
                         "string-width": "2.1.1",
@@ -10102,12 +9970,6 @@
                     "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
                     "dev": true
                 },
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                    "dev": true
-                },
                 "is-glob": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
@@ -10138,16 +10000,6 @@
                         "regex-cache": "0.4.4"
                     }
                 },
-                "string-width": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-                    "dev": true,
-                    "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
-                    }
-                },
                 "strip-ansi": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -10172,7 +10024,7 @@
                     "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
                     "dev": true,
                     "requires": {
-                        "cliui": "4.0.0",
+                        "cliui": "4.1.0",
                         "decamelize": "1.2.0",
                         "find-up": "2.1.0",
                         "get-caller-file": "1.0.2",
@@ -10209,7 +10061,7 @@
             "integrity": "sha512-JXA0gVs5YL0HtLDCGa9YxcmmV2LZbwJ+0MfyXBBc5qpgkEYITQFJP7XNhcHFbUvRiniRpRbGVfJrOoYhhGE0RQ==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.0",
+                "chalk": "2.4.1",
                 "jest-diff": "22.4.3",
                 "jest-matcher-utils": "22.4.3",
                 "mkdirp": "0.5.1",
@@ -10227,9 +10079,9 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
@@ -10261,7 +10113,7 @@
             "dev": true,
             "requires": {
                 "callsites": "2.0.0",
-                "chalk": "2.4.0",
+                "chalk": "2.4.1",
                 "graceful-fs": "4.1.11",
                 "is-ci": "1.0.10",
                 "jest-message-util": "22.4.3",
@@ -10285,9 +10137,9 @@
                     "dev": true
                 },
                 "chalk": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
@@ -10324,7 +10176,7 @@
             "integrity": "sha512-CfFM18W3GSP/xgmA4UouIx0ljdtfD2mjeBC6c89Gg17E44D4tQhAcTrZmf9djvipwU30kSTnk6CzcxdCCeSXfA==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.0",
+                "chalk": "2.4.1",
                 "jest-config": "22.4.3",
                 "jest-get-type": "22.4.3",
                 "leven": "2.1.0",
@@ -10341,9 +10193,9 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
@@ -10386,7 +10238,8 @@
         "js-tokens": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+            "dev": true
         },
         "js-yaml": {
             "version": "3.7.0",
@@ -10415,10 +10268,10 @@
                 "babel-preset-es2015": "6.24.1",
                 "babel-preset-stage-1": "6.24.1",
                 "babel-register": "6.26.0",
-                "babylon": "7.0.0-beta.44",
+                "babylon": "7.0.0-beta.46",
                 "colors": "1.1.2",
-                "flow-parser": "0.70.0",
-                "lodash": "4.17.5",
+                "flow-parser": "0.72.0",
+                "lodash": "4.17.10",
                 "micromatch": "2.3.11",
                 "neo-async": "2.5.1",
                 "node-dir": "0.1.8",
@@ -10444,9 +10297,9 @@
                     "dev": true
                 },
                 "babylon": {
-                    "version": "7.0.0-beta.44",
-                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
-                    "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
+                    "version": "7.0.0-beta.46",
+                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.46.tgz",
+                    "integrity": "sha512-WFJlg2WatdkXRFMpk7BN/Uzzkjkcjk+WaqnrSCpay+RYl4ypW9ZetZyT9kNt22IH/BQNst3M6PaaBn9IXsUNrg==",
                     "dev": true
                 },
                 "braces": {
@@ -10528,9 +10381,9 @@
             }
         },
         "jsdom": {
-            "version": "11.8.0",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.8.0.tgz",
-            "integrity": "sha512-fZZSH6P8tVqYIQl0WKpZuQljPu2cW41Uj/c9omtyGwjwZCB8c82UAi7BSQs/F1FgWovmZsoU02z3k28eHp0Cdw==",
+            "version": "11.10.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.10.0.tgz",
+            "integrity": "sha512-x5No5FpJgBg3j5aBwA8ka6eGuS5IxbC8FOkmyccKvObtFT0bDMict/LOxINZsZGZSfGdNomLZ/qRV9Bpq/GIBA==",
             "dev": true,
             "requires": {
                 "abab": "1.0.4",
@@ -10556,7 +10409,7 @@
                 "webidl-conversions": "4.0.2",
                 "whatwg-encoding": "1.0.3",
                 "whatwg-mimetype": "2.1.0",
-                "whatwg-url": "6.4.0",
+                "whatwg-url": "6.4.1",
                 "ws": "4.1.0",
                 "xml-name-validator": "3.0.0"
             },
@@ -10665,9 +10518,9 @@
                     "dev": true
                 },
                 "qs": {
-                    "version": "6.5.1",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-                    "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+                    "version": "6.5.2",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+                    "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
                     "dev": true
                 },
                 "request": {
@@ -10692,8 +10545,8 @@
                         "mime-types": "2.1.18",
                         "oauth-sign": "0.8.2",
                         "performance-now": "2.1.0",
-                        "qs": "6.5.1",
-                        "safe-buffer": "5.1.1",
+                        "qs": "6.5.2",
+                        "safe-buffer": "5.1.2",
                         "stringstream": "0.0.5",
                         "tough-cookie": "2.3.4",
                         "tunnel-agent": "0.6.0",
@@ -10961,7 +10814,7 @@
             "dev": true,
             "requires": {
                 "app-root-path": "2.0.1",
-                "chalk": "2.4.0",
+                "chalk": "2.4.1",
                 "commander": "2.15.1",
                 "cosmiconfig": "4.0.0",
                 "debug": "3.1.0",
@@ -10971,14 +10824,14 @@
                 "is-glob": "4.0.0",
                 "jest-validate": "22.4.3",
                 "listr": "0.13.0",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "log-symbols": "2.2.0",
                 "micromatch": "3.1.10",
                 "npm-which": "3.0.1",
                 "p-map": "1.2.0",
                 "path-is-inside": "1.0.2",
                 "pify": "3.0.0",
-                "please-upgrade-node": "3.0.1",
+                "please-upgrade-node": "3.0.2",
                 "staged-git-files": "1.1.0",
                 "stringify-object": "3.2.2"
             },
@@ -10993,9 +10846,9 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
@@ -11149,7 +11002,7 @@
                     "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.4.0"
+                        "chalk": "2.4.1"
                     }
                 },
                 "stream-to-observable": {
@@ -11292,9 +11145,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.5",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-            "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+            "version": "4.17.10",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+            "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
             "dev": true
         },
         "lodash.camelcase": {
@@ -11371,10 +11224,14 @@
             "dev": true
         },
         "loglevelnext": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/loglevelnext/-/loglevelnext-1.0.4.tgz",
-            "integrity": "sha512-V3N6LAJAiGwa/zjtvmgs2tyeiCJ23bGNhxXN8R+v7k6TNlSlTz40mIyZYdmO762eBnEFymn0Mhha+WuAhnwMBg==",
-            "dev": true
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/loglevelnext/-/loglevelnext-1.0.5.tgz",
+            "integrity": "sha512-V/73qkPuJmx4BcBF19xPBr+0ZRVBhc4POxvZTZdMeXpJ4NItXSJ/MSwuFT0kQJlCbXvdlZoQQ/418bS1y9Jh6A==",
+            "dev": true,
+            "requires": {
+                "es6-symbol": "3.1.1",
+                "object.assign": "4.1.0"
+            }
         },
         "longest": {
             "version": "1.0.1",
@@ -11392,6 +11249,7 @@
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
             "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+            "dev": true,
             "requires": {
                 "js-tokens": "3.0.2"
             }
@@ -11419,21 +11277,13 @@
             "dev": true
         },
         "lru-cache": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
-            "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+            "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
             "dev": true,
             "requires": {
                 "pseudomap": "1.0.2",
                 "yallist": "2.1.2"
-            },
-            "dependencies": {
-                "yallist": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-                    "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-                    "dev": true
-                }
             }
         },
         "macaddress": {
@@ -11443,9 +11293,9 @@
             "dev": true
         },
         "make-dir": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
-            "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+            "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
             "dev": true,
             "requires": {
                 "pify": "3.0.0"
@@ -11505,6 +11355,12 @@
             "integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw=",
             "dev": true
         },
+        "math-random": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+            "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
+            "dev": true
+        },
         "md5.js": {
             "version": "1.3.4",
             "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
@@ -11521,8 +11377,8 @@
             "integrity": "sha1-zbX4TitqLTEU3zO9BdnLMuPECDo=",
             "dev": true,
             "requires": {
-                "unist-util-modify-children": "1.1.1",
-                "unist-util-visit": "1.3.0"
+                "unist-util-modify-children": "1.1.2",
+                "unist-util-visit": "1.3.1"
             }
         },
         "mdast-util-definitions": {
@@ -11531,7 +11387,7 @@
             "integrity": "sha512-9NloPSwaB9f1PKcGqaScfqRf6zKOEjTIXVIbPOmgWI/JKxznlgVXC5C+8qgl3AjYg2vJBRgLYfLICaNiac89iA==",
             "dev": true,
             "requires": {
-                "unist-util-visit": "1.3.0"
+                "unist-util-visit": "1.3.1"
             }
         },
         "mdast-util-inject": {
@@ -11556,9 +11412,9 @@
                 "trim": "0.0.1",
                 "trim-lines": "1.1.1",
                 "unist-builder": "1.0.2",
-                "unist-util-generated": "1.1.1",
-                "unist-util-position": "3.0.0",
-                "unist-util-visit": "1.3.0",
+                "unist-util-generated": "1.1.2",
+                "unist-util-position": "3.0.1",
+                "unist-util-visit": "1.3.1",
                 "xtend": "4.0.1"
             }
         },
@@ -11576,7 +11432,7 @@
             "requires": {
                 "github-slugger": "1.1.3",
                 "mdast-util-to-string": "1.0.4",
-                "unist-util-visit": "1.3.0"
+                "unist-util-visit": "1.3.1"
             }
         },
         "mdurl": {
@@ -11637,16 +11493,17 @@
             }
         },
         "mem-fs-editor": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-3.0.2.tgz",
-            "integrity": "sha1-3Qpuryu4prN3QAZ6pUnrUwEFr58=",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-4.0.2.tgz",
+            "integrity": "sha512-QHvdXLLNmwJXxKdf7x27aNUren6IoPxwcM8Sfd+S6/ddQQMcYdEtVKsh6ilpqMrU18VQuKZEaH0aCGt3JDbA0g==",
             "dev": true,
             "requires": {
                 "commondir": "1.0.1",
-                "deep-extend": "0.4.2",
-                "ejs": "2.5.9",
+                "deep-extend": "0.5.1",
+                "ejs": "2.6.1",
                 "glob": "7.1.2",
-                "globby": "6.1.0",
+                "globby": "8.0.1",
+                "isbinaryfile": "3.0.2",
                 "mkdirp": "0.5.1",
                 "multimatch": "2.1.0",
                 "rimraf": "2.6.2",
@@ -11655,23 +11512,19 @@
             },
             "dependencies": {
                 "globby": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-                    "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+                    "version": "8.0.1",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+                    "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
                     "dev": true,
                     "requires": {
                         "array-union": "1.0.2",
+                        "dir-glob": "2.0.0",
+                        "fast-glob": "2.2.1",
                         "glob": "7.1.2",
-                        "object-assign": "4.1.1",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "ignore": "3.3.8",
+                        "pify": "3.0.0",
+                        "slash": "1.0.0"
                     }
-                },
-                "pify": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-                    "dev": true
                 }
             }
         },
@@ -11846,6 +11699,12 @@
                 "readable-stream": "2.3.6"
             }
         },
+        "merge2": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.2.tgz",
+            "integrity": "sha512-bgM8twH86rWni21thii6WCMQMRMmwqqdW3sGWi9IipnVAszdLXRjwDwAnyrVXo6DuP3AjRMMttZKUB48QWIFGg==",
+            "dev": true
+        },
         "methods": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -11951,26 +11810,6 @@
             "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
             "dev": true
         },
-        "minipass": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
-            "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
-            "dev": true,
-            "requires": {
-                "safe-buffer": "5.1.1",
-                "yallist": "3.0.2"
-            }
-        },
-        "minizlib": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
-            "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "minipass": "2.2.4"
-            }
-        },
         "mississippi": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
@@ -11978,13 +11817,13 @@
             "dev": true,
             "requires": {
                 "concat-stream": "1.6.0",
-                "duplexify": "3.5.4",
+                "duplexify": "3.6.0",
                 "end-of-stream": "1.4.1",
                 "flush-write-stream": "1.0.3",
                 "from2": "2.3.0",
                 "parallel-transform": "1.1.0",
                 "pump": "2.0.1",
-                "pumpify": "1.4.0",
+                "pumpify": "1.5.0",
                 "stream-each": "1.2.2",
                 "through2": "2.0.3"
             }
@@ -12183,30 +12022,6 @@
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
             "dev": true
         },
-        "needle": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
-            "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "debug": "2.6.9",
-                "iconv-lite": "0.4.21",
-                "sax": "1.2.4"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                }
-            }
-        },
         "negotiator": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
@@ -12250,15 +12065,16 @@
             "version": "1.7.3",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
             "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+            "dev": true,
             "requires": {
                 "encoding": "0.1.12",
                 "is-stream": "1.1.0"
             }
         },
         "node-forge": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.1.tgz",
-            "integrity": "sha1-naYR6giYL0uUIGs760zJZl8gwwA=",
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
+            "integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ==",
             "dev": true
         },
         "node-int64": {
@@ -12289,7 +12105,7 @@
                 "querystring-es3": "0.2.1",
                 "readable-stream": "2.3.6",
                 "stream-browserify": "2.0.1",
-                "stream-http": "2.8.1",
+                "stream-http": "2.8.2",
                 "string_decoder": "1.1.1",
                 "timers-browserify": "2.0.10",
                 "tty-browserify": "0.0.0",
@@ -12308,25 +12124,6 @@
                 "semver": "5.5.0",
                 "shellwords": "0.1.1",
                 "which": "1.3.0"
-            }
-        },
-        "node-pre-gyp": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.9.1.tgz",
-            "integrity": "sha1-8RwHUW3ZL4cZnbx+GDjqt81WyeA=",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "detect-libc": "1.0.3",
-                "mkdirp": "0.5.1",
-                "needle": "2.2.0",
-                "nopt": "4.0.1",
-                "npm-packlist": "1.1.10",
-                "npmlog": "4.1.2",
-                "rc": "1.2.6",
-                "rimraf": "2.6.2",
-                "semver": "5.5.0",
-                "tar": "4.4.1"
             }
         },
         "nomnom": {
@@ -12362,17 +12159,6 @@
                     "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
                     "dev": true
                 }
-            }
-        },
-        "nopt": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-            "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "abbrev": "1.1.1",
-                "osenv": "0.1.5"
             }
         },
         "normalize-package-data": {
@@ -12414,24 +12200,6 @@
                 "sort-keys": "1.1.2"
             }
         },
-        "npm-bundled": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
-            "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
-            "dev": true,
-            "optional": true
-        },
-        "npm-packlist": {
-            "version": "1.1.10",
-            "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
-            "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "ignore-walk": "3.0.1",
-                "npm-bundled": "1.0.3"
-            }
-        },
         "npm-path": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.4.tgz",
@@ -12448,7 +12216,7 @@
             "dev": true,
             "requires": {
                 "ansi-styles": "3.2.1",
-                "chalk": "2.4.0",
+                "chalk": "2.4.1",
                 "cross-spawn": "5.1.0",
                 "memory-streams": "0.1.3",
                 "minimatch": "3.0.4",
@@ -12468,9 +12236,9 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
@@ -12515,19 +12283,6 @@
                 "which": "1.3.0"
             }
         },
-        "npmlog": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-            "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "are-we-there-yet": "1.1.4",
-                "console-control-strings": "1.1.0",
-                "gauge": "2.7.4",
-                "set-blocking": "2.0.0"
-            }
-        },
         "nth-check": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
@@ -12564,7 +12319,8 @@
         "object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true
         },
         "object-copy": {
             "version": "0.1.0",
@@ -12601,6 +12357,18 @@
             "dev": true,
             "requires": {
                 "isobject": "3.0.1"
+            }
+        },
+        "object.assign": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+            "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+            "dev": true,
+            "requires": {
+                "define-properties": "1.1.2",
+                "function-bind": "1.1.1",
+                "has-symbols": "1.0.0",
+                "object-keys": "1.0.11"
             }
         },
         "object.getownpropertydescriptors": {
@@ -12787,17 +12555,6 @@
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
             "dev": true
         },
-        "osenv": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-            "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
-            }
-        },
         "output-file-sync": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
@@ -12936,9 +12693,9 @@
             }
         },
         "parse-entities": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.1.1.tgz",
-            "integrity": "sha1-gRLYhHExnyerrk1klksSL+ThuJA=",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.1.2.tgz",
+            "integrity": "sha512-5N9lmQ7tmxfXf+hO3X6KRG6w7uYO/HL9fHalSySTdyn63C3WNvTM/1R8tn1u1larNcEbo3Slcy2bsVDQqvEpUg==",
             "dev": true,
             "requires": {
                 "character-entities": "1.2.2",
@@ -13145,7 +12902,7 @@
                 "create-hash": "1.2.0",
                 "create-hmac": "1.1.7",
                 "ripemd160": "2.0.2",
-                "safe-buffer": "5.1.1",
+                "safe-buffer": "5.1.2",
                 "sha.js": "2.4.11"
             }
         },
@@ -13192,10 +12949,13 @@
             }
         },
         "please-upgrade-node": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.0.1.tgz",
-            "integrity": "sha1-CmgfLBiRXlQzpcos2U4Lggangts=",
-            "dev": true
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.0.2.tgz",
+            "integrity": "sha512-bslfSeW+ksUbB/sYZeEdKFyTG4YWU9YKRvqfSRvZKE675khAuBUPqV5RUwJZaGuWmVQLweK45Q+lPHFVnSlSug==",
+            "dev": true,
+            "requires": {
+                "semver-compare": "1.0.0"
+            }
         },
         "pluralize": {
             "version": "7.0.0",
@@ -13399,8 +13159,8 @@
                     "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
                     "dev": true,
                     "requires": {
-                        "caniuse-db": "1.0.30000830",
-                        "electron-to-chromium": "1.3.42"
+                        "caniuse-db": "1.0.30000839",
+                        "electron-to-chromium": "1.3.45"
                     }
                 }
             }
@@ -13462,7 +13222,7 @@
             "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
             "dev": true,
             "requires": {
-                "postcss": "6.0.21"
+                "postcss": "6.0.22"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -13475,9 +13235,9 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
@@ -13492,12 +13252,12 @@
                     "dev": true
                 },
                 "postcss": {
-                    "version": "6.0.21",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
-                    "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
+                    "version": "6.0.22",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
+                    "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.4.0",
+                        "chalk": "2.4.1",
                         "source-map": "0.6.1",
                         "supports-color": "5.4.0"
                     }
@@ -13526,7 +13286,7 @@
             "dev": true,
             "requires": {
                 "css-selector-tokenizer": "0.7.0",
-                "postcss": "6.0.21"
+                "postcss": "6.0.22"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -13539,9 +13299,9 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
@@ -13556,12 +13316,12 @@
                     "dev": true
                 },
                 "postcss": {
-                    "version": "6.0.21",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
-                    "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
+                    "version": "6.0.22",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
+                    "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.4.0",
+                        "chalk": "2.4.1",
                         "source-map": "0.6.1",
                         "supports-color": "5.4.0"
                     }
@@ -13590,7 +13350,7 @@
             "dev": true,
             "requires": {
                 "css-selector-tokenizer": "0.7.0",
-                "postcss": "6.0.21"
+                "postcss": "6.0.22"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -13603,9 +13363,9 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
@@ -13620,12 +13380,12 @@
                     "dev": true
                 },
                 "postcss": {
-                    "version": "6.0.21",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
-                    "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
+                    "version": "6.0.22",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
+                    "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.4.0",
+                        "chalk": "2.4.1",
                         "source-map": "0.6.1",
                         "supports-color": "5.4.0"
                     }
@@ -13654,7 +13414,7 @@
             "dev": true,
             "requires": {
                 "icss-replace-symbols": "1.1.0",
-                "postcss": "6.0.21"
+                "postcss": "6.0.22"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -13667,9 +13427,9 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
@@ -13684,12 +13444,12 @@
                     "dev": true
                 },
                 "postcss": {
-                    "version": "6.0.21",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
-                    "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
+                    "version": "6.0.22",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
+                    "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.4.0",
+                        "chalk": "2.4.1",
                         "source-map": "0.6.1",
                         "supports-color": "5.4.0"
                     }
@@ -13918,6 +13678,7 @@
             "version": "7.3.1",
             "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
             "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+            "dev": true,
             "requires": {
                 "asap": "2.0.6"
             }
@@ -13932,6 +13693,7 @@
             "version": "15.6.1",
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
             "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+            "dev": true,
             "requires": {
                 "fbjs": "0.8.16",
                 "loose-envify": "1.3.1",
@@ -14005,12 +13767,12 @@
             }
         },
         "pumpify": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz",
-            "integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.0.tgz",
+            "integrity": "sha512-UWi0klDoq8xtVzlMRgENV9F7iCTZExaJQSQL187UXsxpk9NnrKGqTqqUNYAKGOzucSOxs2+jUnRNI+rLviPhJg==",
             "dev": true,
             "requires": {
-                "duplexify": "3.5.4",
+                "duplexify": "3.6.0",
                 "inherits": "2.0.3",
                 "pump": "2.0.1"
             }
@@ -14068,23 +13830,27 @@
             "dev": true
         },
         "randomatic": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-            "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
+            "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "4.0.0",
+                "kind-of": "6.0.2",
+                "math-random": "1.0.1"
             },
             "dependencies": {
-                "kind-of": {
+                "is-number": {
                     "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "1.1.6"
-                    }
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+                    "dev": true
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
                 }
             }
         },
@@ -14094,7 +13860,7 @@
             "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "randomfill": {
@@ -14104,7 +13870,7 @@
             "dev": true,
             "requires": {
                 "randombytes": "2.0.6",
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "range-parser": {
@@ -14131,32 +13897,11 @@
                 }
             }
         },
-        "rc": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
-            "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "deep-extend": "0.4.2",
-                "ini": "1.3.5",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true,
-                    "optional": true
-                }
-            }
-        },
         "react": {
-            "version": "15.6.1",
-            "resolved": "https://registry.npmjs.org/react/-/react-15.6.1.tgz",
-            "integrity": "sha1-uqhDTsZ4C96ZfNw4C3nNM7ljk98=",
+            "version": "15.6.2",
+            "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
+            "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
+            "dev": true,
             "requires": {
                 "create-react-class": "15.6.3",
                 "fbjs": "0.8.16",
@@ -14200,7 +13945,7 @@
             "dev": true,
             "requires": {
                 "create-react-class": "15.6.3",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "mousetrap": "1.6.1",
                 "prop-types": "15.6.1"
             }
@@ -14234,7 +13979,7 @@
             "dev": true,
             "requires": {
                 "pify": "3.0.0",
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "read-pkg": {
@@ -14268,7 +14013,7 @@
                 "inherits": "2.0.3",
                 "isarray": "1.0.0",
                 "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.1",
+                "safe-buffer": "5.1.2",
                 "string_decoder": "1.1.1",
                 "util-deprecate": "1.0.2"
             }
@@ -14482,7 +14227,7 @@
             "requires": {
                 "remark-parse": "4.0.0",
                 "remark-stringify": "4.0.0",
-                "unified": "6.1.6"
+                "unified": "6.2.0"
             }
         },
         "remark-html": {
@@ -14507,16 +14252,16 @@
                 "is-alphabetical": "1.0.2",
                 "is-decimal": "1.0.2",
                 "is-whitespace-character": "1.0.2",
-                "is-word-character": "1.0.1",
+                "is-word-character": "1.0.2",
                 "markdown-escapes": "1.0.2",
-                "parse-entities": "1.1.1",
+                "parse-entities": "1.1.2",
                 "repeat-string": "1.6.1",
                 "state-toggle": "1.0.1",
                 "trim": "0.0.1",
-                "trim-trailing-lines": "1.1.0",
-                "unherit": "1.1.0",
-                "unist-util-remove-position": "1.1.1",
-                "vfile-location": "2.0.2",
+                "trim-trailing-lines": "1.1.1",
+                "unherit": "1.1.1",
+                "unist-util-remove-position": "1.1.2",
+                "vfile-location": "2.0.3",
                 "xtend": "4.0.1"
             }
         },
@@ -14528,7 +14273,7 @@
             "requires": {
                 "github-slugger": "1.1.3",
                 "mdast-util-to-string": "1.0.4",
-                "unist-util-visit": "1.3.0"
+                "unist-util-visit": "1.3.1"
             }
         },
         "remark-stringify": {
@@ -14545,11 +14290,11 @@
                 "markdown-escapes": "1.0.2",
                 "markdown-table": "1.1.2",
                 "mdast-util-compact": "1.0.1",
-                "parse-entities": "1.1.1",
+                "parse-entities": "1.1.2",
                 "repeat-string": "1.6.1",
                 "state-toggle": "1.0.1",
-                "stringify-entities": "1.3.1",
-                "unherit": "1.1.0",
+                "stringify-entities": "1.3.2",
+                "unherit": "1.1.1",
                 "xtend": "4.0.1"
             }
         },
@@ -14649,7 +14394,7 @@
                 "oauth-sign": "0.8.2",
                 "performance-now": "0.2.0",
                 "qs": "6.4.0",
-                "safe-buffer": "5.1.1",
+                "safe-buffer": "5.1.2",
                 "stringstream": "0.0.5",
                 "tough-cookie": "2.3.4",
                 "tunnel-agent": "0.6.0",
@@ -14671,7 +14416,7 @@
             "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
             "dev": true,
             "requires": {
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
             }
         },
         "request-promise-native": {
@@ -14820,6 +14565,12 @@
                 "inherits": "2.0.3"
             }
         },
+        "rsvp": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+            "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+            "dev": true
+        },
         "run-async": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -14841,7 +14592,8 @@
         "rw": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-            "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
+            "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=",
+            "dev": true
         },
         "rx-lite": {
             "version": "4.0.8",
@@ -14868,9 +14620,9 @@
             }
         },
         "safe-buffer": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-            "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
             "dev": true
         },
         "safe-json-parse": {
@@ -14891,18 +14643,20 @@
         "safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true
         },
         "sane": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/sane/-/sane-2.5.0.tgz",
-            "integrity": "sha512-glfKd7YH4UCrh/7dD+UESsr8ylKWRE7UQPoXuz28FgmcF0ViJQhCTCCZHICRKxf8G8O1KdLEn20dcICK54c7ew==",
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
+            "integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
             "dev": true,
             "requires": {
                 "anymatch": "2.0.0",
+                "capture-exit": "1.2.0",
                 "exec-sh": "0.2.1",
                 "fb-watchman": "2.0.0",
-                "fsevents": "1.2.0",
+                "fsevents": "1.2.3",
                 "micromatch": "3.1.10",
                 "minimist": "1.2.0",
                 "walker": "1.0.7",
@@ -14945,18 +14699,24 @@
             "dev": true
         },
         "selfsigned": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.2.tgz",
-            "integrity": "sha1-tESVgNmZKbZbEKSDiTAaZZIIh1g=",
+            "version": "1.10.3",
+            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.3.tgz",
+            "integrity": "sha512-vmZenZ+8Al3NLHkWnhBQ0x6BkML1eCP2xEi3JE+f3D9wW9fipD9NNJHYtE9XJM4TsPaHGZJIamrSI6MTg1dU2Q==",
             "dev": true,
             "requires": {
-                "node-forge": "0.7.1"
+                "node-forge": "0.7.5"
             }
         },
         "semver": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
             "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+            "dev": true
+        },
+        "semver-compare": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+            "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
             "dev": true
         },
         "send": {
@@ -15079,7 +14839,8 @@
         "setimmediate": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-            "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+            "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+            "dev": true
         },
         "setprototypeof": {
             "version": "1.1.0",
@@ -15094,7 +14855,7 @@
             "dev": true,
             "requires": {
                 "inherits": "2.0.3",
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "shebang-command": {
@@ -15177,7 +14938,7 @@
                 "extend-shallow": "2.0.1",
                 "map-cache": "0.2.2",
                 "source-map": "0.5.7",
-                "source-map-resolve": "0.5.1",
+                "source-map-resolve": "0.5.2",
                 "use": "3.1.0"
             },
             "dependencies": {
@@ -15351,12 +15112,12 @@
             "dev": true
         },
         "source-map-resolve": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
-            "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+            "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
             "dev": true,
             "requires": {
-                "atob": "2.1.0",
+                "atob": "2.1.1",
                 "decode-uri-component": "0.2.0",
                 "resolve-url": "0.2.1",
                 "source-map-url": "0.4.0",
@@ -15428,7 +15189,7 @@
                 "debug": "2.6.9",
                 "handle-thing": "1.2.5",
                 "http-deceiver": "1.2.7",
-                "safe-buffer": "5.1.1",
+                "safe-buffer": "5.1.2",
                 "select-hose": "2.0.0",
                 "spdy-transport": "2.1.0"
             },
@@ -15455,7 +15216,7 @@
                 "hpack.js": "2.1.6",
                 "obuf": "1.1.2",
                 "readable-stream": "2.3.6",
-                "safe-buffer": "5.1.1",
+                "safe-buffer": "5.1.2",
                 "wbuf": "1.7.3"
             },
             "dependencies": {
@@ -15524,7 +15285,7 @@
             "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "stack-utils": {
@@ -15656,9 +15417,9 @@
             }
         },
         "stream-http": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.1.tgz",
-            "integrity": "sha512-cQ0jo17BLca2r0GfRdZKYAGLU6JRoIWxqSOakUMuKOT6MOK7AAlE856L33QuDmAy/eeOrhLee3dZKX0Uadu93A==",
+            "version": "2.8.2",
+            "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.2.tgz",
+            "integrity": "sha512-QllfrBhqF1DPcz46WxKTs6Mz1Bpc+8Qm6vbqOpVav5odAXwbyzwnEczoWqtxrsmlO+cJqtPrp/8gWKWjaKLLlA==",
             "dev": true,
             "requires": {
                 "builtin-status-codes": "3.0.0",
@@ -15720,14 +15481,36 @@
             "dev": true
         },
         "string-width": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
             "dev": true,
             "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "3.0.0"
+                    }
+                }
             }
         },
         "string.prototype.padend": {
@@ -15747,13 +15530,13 @@
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "stringify-entities": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.1.tgz",
-            "integrity": "sha1-sVDsLXKsTBtfMktR+2soyc3/BYw=",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
+            "integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
             "dev": true,
             "requires": {
                 "character-entities-html4": "1.1.2",
@@ -15901,18 +15684,12 @@
             "requires": {
                 "ajv": "5.5.2",
                 "ajv-keywords": "2.1.1",
-                "chalk": "2.4.0",
-                "lodash": "4.17.5",
+                "chalk": "2.4.1",
+                "lodash": "4.17.10",
                 "slice-ansi": "1.0.0",
                 "string-width": "2.1.1"
             },
             "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                    "dev": true
-                },
                 "ansi-styles": {
                     "version": "3.2.1",
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -15923,9 +15700,9 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
@@ -15954,25 +15731,6 @@
                         "is-fullwidth-code-point": "2.0.0"
                     }
                 },
-                "string-width": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-                    "dev": true,
-                    "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "3.0.0"
-                    }
-                },
                 "supports-color": {
                     "version": "5.4.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
@@ -15989,22 +15747,6 @@
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
             "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
             "dev": true
-        },
-        "tar": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
-            "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "chownr": "1.0.1",
-                "fs-minipass": "1.2.5",
-                "minipass": "2.2.4",
-                "minizlib": "1.1.0",
-                "mkdirp": "0.5.1",
-                "safe-buffer": "5.1.1",
-                "yallist": "3.0.2"
-            }
         },
         "temp": {
             "version": "0.8.3",
@@ -16282,9 +16024,9 @@
             }
         },
         "toposort": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.6.tgz",
-            "integrity": "sha1-wxdI5V0hDv/AD9zcfW5o19e7nOw=",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.7.tgz",
+            "integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk=",
             "dev": true
         },
         "tough-cookie": {
@@ -16338,9 +16080,9 @@
             "dev": true
         },
         "trim-trailing-lines": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.0.tgz",
-            "integrity": "sha1-eu+7eAjfnWafbaLkOMrIxGradoQ=",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.1.tgz",
+            "integrity": "sha512-bWLv9BbWbbd7mlqqs2oQYnLD/U/ZqeJeJwbO0FG2zA1aTq+HTvxfHNKFa/HGCVyJpDiioUYaBhfiT6rgk+l4mg==",
             "dev": true
         },
         "trough": {
@@ -16361,7 +16103,7 @@
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "tweetnacl": {
@@ -16397,9 +16139,10 @@
             "dev": true
         },
         "ua-parser-js": {
-            "version": "0.7.17",
-            "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
-            "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+            "version": "0.7.18",
+            "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
+            "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA==",
+            "dev": true
         },
         "uglify-js": {
             "version": "2.8.29",
@@ -16457,9 +16200,9 @@
             "dev": true
         },
         "unherit": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.0.tgz",
-            "integrity": "sha1-a5qu379z3xdWrZ4xbdmBiFhAzX0=",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.1.tgz",
+            "integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
             "dev": true,
             "requires": {
                 "inherits": "2.0.3",
@@ -16467,9 +16210,9 @@
             }
         },
         "unified": {
-            "version": "6.1.6",
-            "resolved": "https://registry.npmjs.org/unified/-/unified-6.1.6.tgz",
-            "integrity": "sha512-pW2f82bCIo2ifuIGYcV12fL96kMMYgw7JKVEgh7ODlrM9rj6vXSY3BV+H6lCcv1ksxynFf582hwWLnA1qRFy4w==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
+            "integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
             "dev": true,
             "requires": {
                 "bail": "1.0.3",
@@ -16477,7 +16220,6 @@
                 "is-plain-obj": "1.1.0",
                 "trough": "1.0.2",
                 "vfile": "2.3.0",
-                "x-is-function": "1.0.4",
                 "x-is-string": "0.1.0"
             }
         },
@@ -16592,54 +16334,54 @@
             }
         },
         "unist-util-generated": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.1.tgz",
-            "integrity": "sha1-mfFseJWayFTe58YVwpGSTIv03n8=",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.2.tgz",
+            "integrity": "sha512-1HcwiEO62dr0XWGT+abVK4f0aAm8Ik8N08c5nAYVmuSxfvpA9rCcNyX/le8xXj1pJK5nBrGlZefeWB6bN8Pstw==",
             "dev": true
         },
         "unist-util-is": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.1.tgz",
-            "integrity": "sha1-DDEmKeP5YMZukx6BLT2A53AQlHs=",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.2.tgz",
+            "integrity": "sha512-YkXBK/H9raAmG7KXck+UUpnKiNmUdB+aBGrknfQ4EreE1banuzrKABx3jP6Z5Z3fMSPMQQmeXBlKpCbMwBkxVw==",
             "dev": true
         },
         "unist-util-modify-children": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-1.1.1.tgz",
-            "integrity": "sha1-ZtfmpEnm9nIguXarPLi166w55R0=",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-1.1.2.tgz",
+            "integrity": "sha512-GRi04yhng1WqBf5RBzPkOtWAadcZS2gvuOgNn/cyJBYNxtTuyYqTKN0eg4rC1YJwGnzrqfRB3dSKm8cNCjNirg==",
             "dev": true,
             "requires": {
                 "array-iterate": "1.1.2"
             }
         },
         "unist-util-position": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.0.0.tgz",
-            "integrity": "sha1-5uHgPu64HF4a/lU+jUrfvXwNj4I=",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.0.1.tgz",
+            "integrity": "sha512-05QfJDPI7PE1BIUtAxeSV+cDx21xP7+tUZgSval5CA7tr0pHBwybF7OnEa1dOFqg6BfYH/qiMUnWwWj+Frhlww==",
             "dev": true
         },
         "unist-util-remove-position": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.1.tgz",
-            "integrity": "sha1-WoXBVV/BugwQG4ZwfRXlD6TIcbs=",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.2.tgz",
+            "integrity": "sha512-XxoNOBvq1WXRKXxgnSYbtCF76TJrRoe5++pD4cCBsssSiWSnPEktyFrFLE8LTk3JW5mt9hB0Sk5zn4x/JeWY7Q==",
             "dev": true,
             "requires": {
-                "unist-util-visit": "1.3.0"
+                "unist-util-visit": "1.3.1"
             }
         },
         "unist-util-stringify-position": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.1.tgz",
-            "integrity": "sha1-PMvcU2ee7W7PN3fdf14yKcG2qjw=",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+            "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==",
             "dev": true
         },
         "unist-util-visit": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.3.0.tgz",
-            "integrity": "sha512-9ntYcxPFtl44gnwXrQKZ5bMqXMY0ZHzUpqMFiU4zcc8mmf/jzYm8GhYgezuUlX4cJIM1zIDYaO6fG/fI+L6iiQ==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.3.1.tgz",
+            "integrity": "sha512-0fdB9EQJU0tho5tK0VzOJzAQpPv2LyLZ030b10GxuzAWEfvd54mpY7BMjQ1L69k2YNvL+SvxRzH0yUIehOO8aA==",
             "dev": true,
             "requires": {
-                "unist-util-is": "2.1.1"
+                "unist-util-is": "2.1.2"
             }
         },
         "universalify": {
@@ -16701,9 +16443,9 @@
             "dev": true
         },
         "upath": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/upath/-/upath-1.0.4.tgz",
-            "integrity": "sha512-d4SJySNBXDaQp+DPrziv3xGS6w3d2Xt69FijJr86zMPBy23JEloMCEOUBBzuN7xCtjLCnmB9tI/z7SBCahHBOw==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/upath/-/upath-1.0.5.tgz",
+            "integrity": "sha512-qbKn90aDQ0YEwvXoLqj0oiuUYroLX2lVHZ+b+xwjozFasAOC4GneDq5+OaIG5Zj+jFmbz/uO+f7a9qxjktJQww==",
             "dev": true
         },
         "upper-case": {
@@ -16713,9 +16455,9 @@
             "dev": true
         },
         "uri-js": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
-            "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.1.tgz",
+            "integrity": "sha512-jpKCA3HjsBfSDOEgxRDAxQCNyHfCPSbq57PqCkd3gAyBuPb3IWxw54EHncqESznIdqSetHfw3D7ylThu2Kcc9A==",
             "dev": true,
             "requires": {
                 "punycode": "2.1.0"
@@ -16944,23 +16686,23 @@
             "requires": {
                 "is-buffer": "1.1.6",
                 "replace-ext": "1.0.0",
-                "unist-util-stringify-position": "1.1.1",
-                "vfile-message": "1.0.0"
+                "unist-util-stringify-position": "1.1.2",
+                "vfile-message": "1.0.1"
             }
         },
         "vfile-location": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.2.tgz",
-            "integrity": "sha1-02dcWch3SY5JK0dW/2Xkrxp1IlU=",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.3.tgz",
+            "integrity": "sha512-zM5/l4lfw1CBoPx3Jimxoc5RNDAHHpk6AM6LM0pTIkm5SUSsx8ZekZ0PVdf0WEZ7kjlhSt7ZlqbRL6Cd6dBs6A==",
             "dev": true
         },
         "vfile-message": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.0.0.tgz",
-            "integrity": "sha512-HPREhzTOB/sNDc9/Mxf8w0FmHnThg5CRSJdR9VRFkD2riqYWs+fuXlj5z8mIpv2LrD7uU41+oPWFOL4Mjlf+dw==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.0.1.tgz",
+            "integrity": "sha512-vSGCkhNvJzO6VcWC6AlJW4NtYOVtS+RgCaqFIYUjoGIlHnFL+i0LbtYvonDWOMcB97uTPT4PRsyYY7REWC9vug==",
             "dev": true,
             "requires": {
-                "unist-util-stringify-position": "1.1.1"
+                "unist-util-stringify-position": "1.1.2"
             }
         },
         "vfile-reporter": {
@@ -16972,10 +16714,21 @@
                 "repeat-string": "1.6.1",
                 "string-width": "1.0.2",
                 "supports-color": "4.5.0",
-                "unist-util-stringify-position": "1.1.1",
-                "vfile-statistics": "1.1.0"
+                "unist-util-stringify-position": "1.1.2",
+                "vfile-statistics": "1.1.1"
             },
             "dependencies": {
+                "string-width": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                    }
+                },
                 "supports-color": {
                     "version": "4.5.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
@@ -16988,15 +16741,15 @@
             }
         },
         "vfile-sort": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/vfile-sort/-/vfile-sort-2.1.0.tgz",
-            "integrity": "sha1-SVAcnou+Wt/y6bOnZx7hseIMUhA=",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/vfile-sort/-/vfile-sort-2.1.1.tgz",
+            "integrity": "sha512-+fpTWKkVHwI6VF2xtkDTuCA6cH4UPLAxh+KxfU8g8pC0do5RSZCk1HXTTtMJguW0t5jC0PC19owjUZX9SGQ9tw==",
             "dev": true
         },
         "vfile-statistics": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/vfile-statistics/-/vfile-statistics-1.1.0.tgz",
-            "integrity": "sha1-AhBMYP3u0dEbH3OtZTMLdjSz2JU=",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/vfile-statistics/-/vfile-statistics-1.1.1.tgz",
+            "integrity": "sha512-dxUM6IYvGChHuwMT3dseyU5BHprNRXzAV0OHx1A769lVGsTiT50kU7BbpRFV+IE6oWmU+PwHdsTKfXhnDIRIgQ==",
             "dev": true
         },
         "vinyl": {
@@ -17005,7 +16758,7 @@
             "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
             "dev": true,
             "requires": {
-                "clone": "2.1.2",
+                "clone": "2.1.1",
                 "clone-buffer": "1.0.0",
                 "clone-stats": "1.0.0",
                 "cloneable-readable": "1.1.2",
@@ -17014,9 +16767,9 @@
             },
             "dependencies": {
                 "clone": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+                    "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
                     "dev": true
                 }
             }
@@ -17100,7 +16853,7 @@
             "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
             "dev": true,
             "requires": {
-                "duplexify": "3.5.4",
+                "duplexify": "3.6.0",
                 "glob-stream": "5.3.5",
                 "graceful-fs": "4.1.11",
                 "gulp-sourcemaps": "1.6.0",
@@ -17199,9 +16952,9 @@
             }
         },
         "watchpack": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.5.0.tgz",
-            "integrity": "sha512-RSlipNQB1u48cq0wH/BNfCu1tD/cJ8ydFIkNYhp9o+3d+8unClkIovpW5qpFPgmL9OE48wfAnlZydXByWP82AA==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
+            "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
             "dev": true,
             "requires": {
                 "chokidar": "2.0.3",
@@ -17232,8 +16985,8 @@
             "requires": {
                 "acorn": "5.5.3",
                 "acorn-dynamic-import": "3.0.0",
-                "ajv": "6.4.0",
-                "ajv-keywords": "3.1.0",
+                "ajv": "6.5.0",
+                "ajv-keywords": "3.2.0",
                 "chrome-trace-event": "0.1.3",
                 "enhanced-resolve": "4.0.0",
                 "eslint-scope": "3.7.1",
@@ -17247,7 +17000,7 @@
                 "schema-utils": "0.4.5",
                 "tapable": "1.0.0",
                 "uglifyjs-webpack-plugin": "1.2.5",
-                "watchpack": "1.5.0",
+                "watchpack": "1.6.0",
                 "webpack-sources": "1.1.0"
             },
             "dependencies": {
@@ -17261,21 +17014,21 @@
                     }
                 },
                 "ajv": {
-                    "version": "6.4.0",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
-                    "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
+                    "version": "6.5.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.0.tgz",
+                    "integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
                     "dev": true,
                     "requires": {
-                        "fast-deep-equal": "1.1.0",
+                        "fast-deep-equal": "2.0.1",
                         "fast-json-stable-stringify": "2.0.0",
                         "json-schema-traverse": "0.3.1",
-                        "uri-js": "3.0.2"
+                        "uri-js": "4.2.1"
                     }
                 },
                 "ajv-keywords": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
-                    "integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74=",
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
+                    "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
                     "dev": true
                 },
                 "commander": {
@@ -17295,14 +17048,20 @@
                         "tapable": "1.0.0"
                     }
                 },
+                "fast-deep-equal": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+                    "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+                    "dev": true
+                },
                 "schema-utils": {
                     "version": "0.4.5",
                     "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.5.tgz",
                     "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
                     "dev": true,
                     "requires": {
-                        "ajv": "6.4.0",
-                        "ajv-keywords": "3.1.0"
+                        "ajv": "6.5.0",
+                        "ajv-keywords": "3.2.0"
                     }
                 },
                 "source-map": {
@@ -17444,8 +17203,8 @@
                         "babel-register": "6.26.0",
                         "babylon": "6.18.0",
                         "colors": "1.1.2",
-                        "flow-parser": "0.70.0",
-                        "lodash": "4.17.5",
+                        "flow-parser": "0.72.0",
+                        "lodash": "4.17.10",
                         "micromatch": "2.3.11",
                         "node-dir": "0.1.8",
                         "nomnom": "1.8.1",
@@ -17482,7 +17241,7 @@
                     "dev": true,
                     "requires": {
                         "ast-types": "0.10.1",
-                        "core-js": "2.5.5",
+                        "core-js": "2.5.6",
                         "esprima": "4.0.0",
                         "private": "0.1.8",
                         "source-map": "0.6.1"
@@ -17513,19 +17272,19 @@
             "integrity": "sha512-kMi6NquWwUhmQok2IFrtAEIbaVvujzYvtDGb5WElkwylbLboDsCgizv8IjSi/Q6SQRJ8Crayl1JCBnIJ3rU4Rg==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.0",
+                "chalk": "2.4.1",
                 "cross-spawn": "6.0.5",
                 "diff": "3.5.0",
                 "enhanced-resolve": "4.0.0",
                 "glob-all": "3.1.0",
                 "global-modules": "1.0.0",
-                "got": "8.3.0",
+                "got": "8.3.1",
                 "inquirer": "5.2.0",
                 "interpret": "1.1.0",
                 "jscodeshift": "0.5.0",
                 "listr": "0.13.0",
                 "loader-utils": "1.1.0",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "log-symbols": "2.2.0",
                 "mkdirp": "0.5.1",
                 "p-each-series": "1.0.0",
@@ -17537,7 +17296,7 @@
                 "webpack-addons": "1.1.5",
                 "yargs": "11.0.0",
                 "yeoman-environment": "2.0.6",
-                "yeoman-generator": "2.0.4"
+                "yeoman-generator": "2.0.5"
             },
             "dependencies": {
                 "ansi-escapes": {
@@ -17568,9 +17327,9 @@
                     "dev": true
                 },
                 "chalk": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
@@ -17588,9 +17347,9 @@
                     }
                 },
                 "cliui": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
-                    "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+                    "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
                     "dev": true,
                     "requires": {
                         "string-width": "2.1.1",
@@ -17650,12 +17409,12 @@
                     "dev": true,
                     "requires": {
                         "ansi-escapes": "3.1.0",
-                        "chalk": "2.4.0",
+                        "chalk": "2.4.1",
                         "cli-cursor": "2.1.0",
                         "cli-width": "2.2.0",
                         "external-editor": "2.2.0",
                         "figures": "2.0.0",
-                        "lodash": "4.17.5",
+                        "lodash": "4.17.10",
                         "mute-stream": "0.0.7",
                         "run-async": "2.3.0",
                         "rxjs": "5.5.10",
@@ -17663,12 +17422,6 @@
                         "strip-ansi": "4.0.0",
                         "through": "2.3.8"
                     }
-                },
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                    "dev": true
                 },
                 "listr": {
                     "version": "0.13.0",
@@ -17845,7 +17598,7 @@
                     "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.4.0"
+                        "chalk": "2.4.1"
                     }
                 },
                 "onetime": {
@@ -17874,16 +17627,6 @@
                     "dev": true,
                     "requires": {
                         "any-observable": "0.2.0"
-                    }
-                },
-                "string-width": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-                    "dev": true,
-                    "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -17916,7 +17659,7 @@
                     "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
                     "dev": true,
                     "requires": {
-                        "cliui": "4.0.0",
+                        "cliui": "4.1.0",
                         "decamelize": "1.2.0",
                         "find-up": "2.1.0",
                         "get-caller-file": "1.0.2",
@@ -17994,7 +17737,7 @@
                 "loglevel": "1.6.1",
                 "opn": "5.3.0",
                 "portfinder": "1.0.13",
-                "selfsigned": "1.10.2",
+                "selfsigned": "1.10.3",
                 "serve-index": "1.9.1",
                 "sockjs": "0.3.19",
                 "sockjs-client": "1.1.4",
@@ -18019,9 +17762,9 @@
                     "dev": true
                 },
                 "cliui": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
-                    "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+                    "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
                     "dev": true,
                     "requires": {
                         "string-width": "2.1.1",
@@ -18081,33 +17824,6 @@
                     "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
                     "dev": true
                 },
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                    "dev": true
-                },
-                "string-width": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-                    "dev": true,
-                    "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
-                    },
-                    "dependencies": {
-                        "strip-ansi": {
-                            "version": "4.0.0",
-                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                            "dev": true,
-                            "requires": {
-                                "ansi-regex": "3.0.0"
-                            }
-                        }
-                    }
-                },
                 "supports-color": {
                     "version": "5.4.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
@@ -18123,7 +17839,7 @@
                     "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
                     "dev": true,
                     "requires": {
-                        "cliui": "4.0.0",
+                        "cliui": "4.1.0",
                         "decamelize": "1.2.0",
                         "find-up": "2.1.0",
                         "get-caller-file": "1.0.2",
@@ -18154,9 +17870,9 @@
             "integrity": "sha512-U9AnICnu50HXtiqiDxuli5gLB5PGBo7VvcHx36jRZHwK4vzOYLbImqT4lwWwoMHdQWwEKw736fCHEekokTEKHA==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.0",
+                "chalk": "2.4.1",
                 "log-symbols": "2.2.0",
-                "loglevelnext": "1.0.4",
+                "loglevelnext": "1.0.5",
                 "uuid": "3.2.1"
             },
             "dependencies": {
@@ -18170,9 +17886,9 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
@@ -18192,7 +17908,7 @@
                     "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.4.0"
+                        "chalk": "2.4.1"
                     }
                 },
                 "supports-color": {
@@ -18257,7 +17973,7 @@
                         "core-js": "1.2.7",
                         "loose-envify": "1.3.1",
                         "promise": "7.3.1",
-                        "ua-parser-js": "0.7.17",
+                        "ua-parser-js": "0.7.18",
                         "whatwg-fetch": "0.9.0"
                     }
                 },
@@ -18291,7 +18007,7 @@
             "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
             "dev": true,
             "requires": {
-                "http-parser-js": "0.4.11",
+                "http-parser-js": "0.4.12",
                 "websocket-extensions": "0.1.3"
             }
         },
@@ -18321,7 +18037,8 @@
         "whatwg-fetch": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-            "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+            "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
+            "dev": true
         },
         "whatwg-mimetype": {
             "version": "2.1.0",
@@ -18330,9 +18047,9 @@
             "dev": true
         },
         "whatwg-url": {
-            "version": "6.4.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
-            "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.1.tgz",
+            "integrity": "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
             "dev": true,
             "requires": {
                 "lodash.sortby": "4.7.0",
@@ -18360,16 +18077,6 @@
             "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
             "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
             "dev": true
-        },
-        "wide-align": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-            "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "string-width": "1.0.2"
-            }
         },
         "window-size": {
             "version": "0.1.0",
@@ -18400,6 +18107,19 @@
             "requires": {
                 "string-width": "1.0.2",
                 "strip-ansi": "3.0.1"
+            },
+            "dependencies": {
+                "string-width": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                    }
+                }
             }
         },
         "wrappy": {
@@ -18435,14 +18155,8 @@
             "dev": true,
             "requires": {
                 "async-limiter": "1.0.0",
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.1.2"
             }
-        },
-        "x-is-function": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/x-is-function/-/x-is-function-1.0.4.tgz",
-            "integrity": "sha1-XSlNw9Joy90GJYDgxd93o5HR+h4=",
-            "dev": true
         },
         "x-is-string": {
             "version": "0.1.0",
@@ -18459,7 +18173,8 @@
         "xmlhttprequest": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-            "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
+            "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
+            "dev": true
         },
         "xtend": {
             "version": "4.0.1",
@@ -18474,9 +18189,9 @@
             "dev": true
         },
         "yallist": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-            "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
             "dev": true
         },
         "yargs": {
@@ -18500,12 +18215,6 @@
                 "yargs-parser": "7.0.0"
             },
             "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                    "dev": true
-                },
                 "camelcase": {
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
@@ -18532,33 +18241,6 @@
                                 "code-point-at": "1.1.0",
                                 "is-fullwidth-code-point": "1.0.0",
                                 "strip-ansi": "3.0.1"
-                            }
-                        }
-                    }
-                },
-                "string-width": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-                    "dev": true,
-                    "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
-                    },
-                    "dependencies": {
-                        "is-fullwidth-code-point": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                            "dev": true
-                        },
-                        "strip-ansi": {
-                            "version": "4.0.0",
-                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                            "dev": true,
-                            "requires": {
-                                "ansi-regex": "3.0.0"
                             }
                         }
                     }
@@ -18598,7 +18280,7 @@
             "integrity": "sha512-jzHBTTy8EPI4ImV8dpUMt+Q5zELkSU5xvGpndHcHudQ4tqN6YgIWaCGmRFl+HDchwRUkcgyjQ+n6/w5zlJBCPg==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.0",
+                "chalk": "2.4.1",
                 "debug": "3.1.0",
                 "diff": "3.5.0",
                 "escape-string-regexp": "1.0.5",
@@ -18606,7 +18288,7 @@
                 "grouped-queue": "0.3.3",
                 "inquirer": "3.3.0",
                 "is-scoped": "1.0.0",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "log-symbols": "2.2.0",
                 "mem-fs": "1.1.3",
                 "text-table": "0.2.0",
@@ -18623,9 +18305,9 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
@@ -18664,7 +18346,7 @@
                     "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.4.0"
+                        "chalk": "2.4.1"
                     }
                 },
                 "pify": {
@@ -18685,15 +18367,15 @@
             }
         },
         "yeoman-generator": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-2.0.4.tgz",
-            "integrity": "sha512-Sgvz3MAkOpEIobcpW3rjEl6bOTNnl8SkibP9z7hYKfIGIlw0QDC2k0MAeXvyE2pLqc2M0Duql+6R7/W9GrJojg==",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-2.0.5.tgz",
+            "integrity": "sha512-rV6tJ8oYzm4mmdF2T3wjY+Q42jKF2YiiD0VKfJ8/0ZYwmhCKC9Xs2346HVLPj/xE13i68psnFJv7iS6gWRkeAg==",
             "dev": true,
             "requires": {
                 "async": "2.6.0",
-                "chalk": "2.4.0",
+                "chalk": "2.4.1",
                 "cli-table": "0.3.1",
-                "cross-spawn": "5.1.0",
+                "cross-spawn": "6.0.5",
                 "dargs": "5.1.0",
                 "dateformat": "3.0.3",
                 "debug": "3.1.0",
@@ -18702,16 +18384,16 @@
                 "find-up": "2.1.0",
                 "github-username": "4.1.0",
                 "istextorbinary": "2.2.1",
-                "lodash": "4.17.5",
-                "make-dir": "1.2.0",
-                "mem-fs-editor": "3.0.2",
+                "lodash": "4.17.10",
+                "make-dir": "1.3.0",
+                "mem-fs-editor": "4.0.2",
                 "minimist": "1.2.0",
                 "pretty-bytes": "4.0.2",
                 "read-chunk": "2.1.0",
                 "read-pkg-up": "3.0.0",
                 "rimraf": "2.6.2",
                 "run-async": "2.3.0",
-                "shelljs": "0.8.1",
+                "shelljs": "0.8.2",
                 "text-table": "0.2.0",
                 "through2": "2.0.3",
                 "yeoman-environment": "2.0.6"
@@ -18727,14 +18409,27 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
                         "supports-color": "5.4.0"
+                    }
+                },
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                    "dev": true,
+                    "requires": {
+                        "nice-try": "1.0.4",
+                        "path-key": "2.0.1",
+                        "semver": "5.5.0",
+                        "shebang-command": "1.2.0",
+                        "which": "1.3.0"
                     }
                 },
                 "has-flag": {
@@ -18802,9 +18497,9 @@
                     }
                 },
                 "shelljs": {
-                    "version": "0.8.1",
-                    "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.1.tgz",
-                    "integrity": "sha512-YA/iYtZpzFe5HyWVGrb02FjPxc4EMCfpoU/Phg9fQoyMC72u9598OUBrsU8IrtwAKG0tO8IYaqbaLIw+k3IRGA==",
+                    "version": "0.8.2",
+                    "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
+                    "integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
                     "dev": true,
                     "requires": {
                         "glob": "7.1.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
             "git add"
         ]
     },
-    "dependencies": {
+    "peerDependencies": {
         "d3": "^4.10.2",
         "react": "^15.6.1"
     },
@@ -54,6 +54,7 @@
         "css-loader": "0.28.7",
         "cypress": "2.1.0",
         "documentation": "5.3.2",
+        "d3": "^4.10.2",
         "eslint": "4.19.1",
         "eslint-config-recommended": "2.0.0",
         "eslint-plugin-jest": "21.15.0",
@@ -67,6 +68,7 @@
         "lint-staged": "7.0.0",
         "npm-run-all": "4.1.1",
         "prettier": "1.11.1",
+        "react": "^15.6.1",
         "react-addons-test-utils": "15.6.0",
         "react-dom": "15.6.1",
         "react-editable-json-tree": "2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,11 +2,17 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@7.0.0-beta.44", "@babel/code-frame@^7.0.0-beta.35":
+"@babel/code-frame@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz#2a02643368de80916162be70865c97774f3adbd9"
   dependencies:
     "@babel/highlight" "7.0.0-beta.44"
+
+"@babel/code-frame@^7.0.0-beta.35":
+  version "7.0.0-beta.46"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.46.tgz#e0d002100805daab1461c0fcb32a07e304f3a4f4"
+  dependencies:
+    "@babel/highlight" "7.0.0-beta.46"
 
 "@babel/generator@7.0.0-beta.44":
   version "7.0.0-beta.44"
@@ -41,6 +47,14 @@
 "@babel/highlight@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.44.tgz#18c94ce543916a80553edcdcf681890b200747d5"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
+"@babel/highlight@7.0.0-beta.46":
+  version "7.0.0-beta.46"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.46.tgz#c553c51e65f572bdedd6eff66fc0bb563016645e"
   dependencies:
     chalk "^2.0.0"
     esutils "^2.0.2"
@@ -106,6 +120,13 @@
   dependencies:
     lodash.once "^4.1.1"
 
+"@mrmlnc/readdir-enhanced@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
+  dependencies:
+    call-me-maybe "^1.0.1"
+    glob-to-regexp "^0.3.0"
+
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
@@ -161,8 +182,8 @@
     "@types/sinon" "*"
 
 "@types/sinon@*":
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-4.3.1.tgz#32458f9b166cd44c23844eee4937814276f35199"
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-4.3.3.tgz#97cbbfddc3282b5fd40c7abf80b99db426fd4237"
 
 "@types/sinon@4.0.0":
   version "4.0.0"
@@ -231,8 +252,8 @@ ajv-keywords@^2.0.0, ajv-keywords@^2.1.0:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
 
 ajv-keywords@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.1.0.tgz#ac2b27939c543e95d2c06e7f7f5c27be4aa543be"
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a"
 
 ajv@^4.9.1:
   version "4.11.8"
@@ -251,13 +272,13 @@ ajv@^5.0.0, ajv@^5.1.0, ajv@^5.1.5, ajv@^5.2.3, ajv@^5.3.0:
     json-schema-traverse "^0.3.0"
 
 ajv@^6.1.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.4.0.tgz#d3aff78e9277549771daf0164cff48482b754fc6"
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.0.tgz#4c8affdf80887d8f132c9c52ab8a2dc4d0b7b24c"
   dependencies:
-    fast-deep-equal "^1.0.0"
+    fast-deep-equal "^2.0.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
-    uri-js "^3.0.2"
+    uri-js "^4.2.1"
 
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
@@ -515,9 +536,9 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
-atob@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.0.tgz#ab2b150e51d7b122b9efc8d7340c06b6c41076bc"
+atob@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"
 
 autoprefixer@^6.3.1:
   version "6.7.7"
@@ -571,7 +592,7 @@ babel-code-frame@^6.11.0, babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@6.26.0, babel-core@^6.0.0, babel-core@^6.0.14, babel-core@^6.17.0, babel-core@^6.26.0:
+babel-core@6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.0.tgz#af32f78b31a6fcef119c87b0fd8d9753f03a0bb8"
   dependencies:
@@ -594,6 +615,30 @@ babel-core@6.26.0, babel-core@^6.0.0, babel-core@^6.0.14, babel-core@^6.17.0, ba
     private "^0.1.7"
     slash "^1.0.0"
     source-map "^0.5.6"
+
+babel-core@^6.0.0, babel-core@^6.0.14, babel-core@^6.17.0, babel-core@^6.26.0:
+  version "6.26.3"
+  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-generator "^6.26.0"
+    babel-helpers "^6.24.1"
+    babel-messages "^6.23.0"
+    babel-register "^6.26.0"
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    convert-source-map "^1.5.1"
+    debug "^2.6.9"
+    json5 "^0.5.1"
+    lodash "^4.17.4"
+    minimatch "^3.0.4"
+    path-is-absolute "^1.0.1"
+    private "^0.1.8"
+    slash "^1.0.0"
+    source-map "^0.5.7"
 
 babel-eslint@^8.0.2:
   version "8.2.3"
@@ -998,8 +1043,8 @@ babel-plugin-transform-es2015-modules-amd@^6.22.0, babel-plugin-transform-es2015
     babel-template "^6.24.1"
 
 babel-plugin-transform-es2015-modules-commonjs@^6.23.0, babel-plugin-transform-es2015-modules-commonjs@^6.24.1:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz#0d8394029b7dc6abe1a97ef181e00758dd2e5d8a"
+  version "6.26.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz#58a793863a9e7ca870bdc5a881117ffac27db6f3"
   dependencies:
     babel-plugin-transform-strict-mode "^6.24.1"
     babel-runtime "^6.26.0"
@@ -1355,13 +1400,17 @@ babelify@^7.3.0:
     babel-core "^6.0.14"
     object-assign "^4.0.0"
 
-babylon@7.0.0-beta.44, babylon@^7.0.0-beta.30:
+babylon@7.0.0-beta.44:
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.44.tgz#89159e15e6e30c5096e22d738d8c0af8a0e8ca1d"
 
 babylon@^6.17.2, babylon@^6.17.3, babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
+
+babylon@^7.0.0-beta.30:
+  version "7.0.0-beta.46"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.46.tgz#b6ddaba81bbb130313932757ff9c195d527088b6"
 
 bail@^1.0.0:
   version "1.0.3"
@@ -1690,6 +1739,10 @@ cacheable-request@^2.1.1:
     normalize-url "2.0.1"
     responselike "1.0.2"
 
+call-me-maybe@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.1.tgz#26d208ea89e37b5cbde60250a15f031c16a4d66b"
+
 caller-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
@@ -1744,12 +1797,18 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000830"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000830.tgz#6e45255b345649fd15ff59072da1e12bb3de2f13"
+  version "1.0.30000839"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000839.tgz#55a86e402c74ae17149707bea3ea399522233497"
 
 caniuse-lite@^1.0.30000792:
-  version "1.0.30000830"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000830.tgz#cb96b8a2dd3cbfe04acea2af3c4e894249095328"
+  version "1.0.30000839"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000839.tgz#41fcc036cf1cb77a0e0be041210f77f1ced44a7b"
+
+capture-exit@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-1.2.0.tgz#1c5fcc489fd0ab00d4f1ac7ae1072e3173fbab6f"
+  dependencies:
+    rsvp "^3.3.3"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1784,9 +1843,9 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.3.2:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.0.tgz#a060a297a6b57e15b61ca63ce84995daa0fe6e52"
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.3.2, chalk@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
@@ -1951,8 +2010,8 @@ cliui@^3.2.0:
     wrap-ansi "^2.0.0"
 
 cliui@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.0.0.tgz#743d4650e05f36d1ed2575b59638d87322bfbbcc"
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
   dependencies:
     string-width "^2.1.1"
     strip-ansi "^4.0.0"
@@ -1981,8 +2040,8 @@ clone@^1.0.0, clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
 
 clone@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.1.tgz#d217d1e961118e3ac9a4b8bba3285553bf647cdb"
 
 cloneable-readable@^1.0.0:
   version "1.1.2"
@@ -2054,8 +2113,8 @@ colors@1.0.3:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
 
 colors@^1.1.2:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.2.1.tgz#f4a3d302976aaf042356ba1ade3b1a2c62d9d794"
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.2.5.tgz#89c7ad9a374bc030df8013241f68136ed8835afc"
 
 colors@~1.1.2:
   version "1.1.2"
@@ -2198,7 +2257,7 @@ continuable-cache@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/continuable-cache/-/continuable-cache-0.3.1.tgz#bd727a7faed77e71ff3985ac93351a912733ad0f"
 
-convert-source-map@^1.1.1, convert-source-map@^1.4.0, convert-source-map@^1.5.0:
+convert-source-map@^1.1.1, convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
 
@@ -2230,8 +2289,8 @@ core-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
 core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.5.tgz#b14dde936c640c0579a6b50cabcc132dd6127e3b"
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.6.tgz#0fe6d45bf3cac3ac364a9d72de7576f4eb221b9d"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -2251,8 +2310,8 @@ cosmiconfig@^4.0.0:
     require-from-string "^2.0.1"
 
 create-ecdh@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.1.tgz#44223dfed533193ba5ba54e0df5709b89acf1f82"
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.3.tgz#c9111b6f33045c4697f144787f9254cdc77c45ff"
   dependencies:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
@@ -2515,8 +2574,8 @@ d3-collection@1, d3-collection@1.0.4:
   resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.4.tgz#342dfd12837c90974f33f1cc0a785aea570dcdc2"
 
 d3-color@1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.1.0.tgz#73957299b63ca935bf19c6c9d835e90066028329"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.2.0.tgz#d1ea19db5859c86854586276ec892cf93148459a"
 
 d3-color@1.0.3:
   version "1.0.3"
@@ -2554,7 +2613,11 @@ d3-force@1.1.0:
     d3-quadtree "1"
     d3-timer "1"
 
-d3-format@1, d3-format@1.2.2:
+d3-format@1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.3.0.tgz#a3ac44269a2011cdb87c7b5693040c18cddfff11"
+
+d3-format@1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.2.2.tgz#1a39c479c8a57fe5051b2e67a3bee27061a74e7a"
 
@@ -2568,7 +2631,13 @@ d3-hierarchy@1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-1.1.5.tgz#a1c845c42f84a206bcf1c01c01098ea4ddaa7a26"
 
-d3-interpolate@1, d3-interpolate@1.1.6:
+d3-interpolate@1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.2.0.tgz#40d81bd8e959ff021c5ea7545bc79b8d22331c41"
+  dependencies:
+    d3-color "1"
+
+d3-interpolate@1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.1.6.tgz#2cf395ae2381804df08aa1bf766b7f97b5f68fb6"
   dependencies:
@@ -2735,7 +2804,7 @@ date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
-dateformat@^3.0.2:
+dateformat@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
 
@@ -2773,9 +2842,9 @@ deep-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
-deep-extend@^0.4.0, deep-extend@~0.4.0:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
+deep-extend@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.5.1.tgz#b894a9dd90d3023fbf1c55a394fb858eb2066f1f"
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -2917,6 +2986,13 @@ diffie-hellman@^5.0.0:
     bn.js "^4.1.0"
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
+
+dir-glob@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.0.0.tgz#0b205d2b6aef98238ca286598a8204d29d0a0034"
+  dependencies:
+    arrify "^1.0.1"
+    path-type "^3.0.0"
 
 disparity@^2.0.0:
   version "2.0.0"
@@ -3079,9 +3155,9 @@ duplexer@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
 
-duplexify@^3.2.0, duplexify@^3.4.2, duplexify@^3.5.3:
-  version "3.5.4"
-  resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.5.4.tgz#4bb46c1796eabebeec4ca9a2e66b808cb7a3d8b4"
+duplexify@^3.2.0, duplexify@^3.4.2, duplexify@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.6.0.tgz#592903f5d80b38d037220541264d69a198fb3410"
   dependencies:
     end-of-stream "^1.0.0"
     inherits "^2.0.1"
@@ -3111,13 +3187,13 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
-ejs@^2.3.1:
-  version "2.5.9"
-  resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.9.tgz#7ba254582a560d267437109a68354112475b0ce5"
+ejs@^2.5.9:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.6.1.tgz#498ec0d495655abc6f23cd61868d926464071aa0"
 
 electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30:
-  version "1.3.42"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.42.tgz#95c33bf01d0cc405556aec899fe61fd4d76ea0f9"
+  version "1.3.45"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.45.tgz#458ac1b1c5c760ce8811a16d2bfbd97ec30bafb8"
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -3377,9 +3453,18 @@ eslint-plugin-react-native@^3.2.0:
   dependencies:
     eslint-plugin-react-native-globals "^0.1.1"
 
-eslint-plugin-react@7.7.0, eslint-plugin-react@^7.5.0:
+eslint-plugin-react@7.7.0:
   version "7.7.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz#f606c719dbd8a1a2b3d25c16299813878cca0160"
+  dependencies:
+    doctrine "^2.0.2"
+    has "^1.0.1"
+    jsx-ast-utils "^2.0.1"
+    prop-types "^15.6.0"
+
+eslint-plugin-react@^7.5.0:
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.8.1.tgz#6bfb5288227645eb7ca3ba8810b87024e0d6c993"
   dependencies:
     doctrine "^2.0.2"
     has "^1.0.1"
@@ -3511,8 +3596,8 @@ event-stream@~3.3.0:
     through "~2.3.1"
 
 eventemitter3@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.0.1.tgz#4ce66c3fc5b5a6b9f2245e359e1938f1ab10f960"
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
 
 events@^1.0.0:
   version "1.1.1"
@@ -3710,6 +3795,20 @@ fast-deep-equal@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
 
+fast-deep-equal@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+
+fast-glob@^2.0.2:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.1.tgz#686c2345be88f3741e174add0be6f2e5b6078889"
+  dependencies:
+    "@mrmlnc/readdir-enhanced" "^2.2.1"
+    glob-parent "^3.1.0"
+    is-glob "^4.0.0"
+    merge2 "^1.2.1"
+    micromatch "^3.1.10"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
@@ -3800,12 +3899,12 @@ fileset@^2.0.2:
     minimatch "^3.0.3"
 
 fill-range@^2.1.0:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.3.tgz#50b77dfd7e469bc7492470963699fe7a8485a723"
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.4.tgz#eb1e773abb056dcd8df2bfdf6af59b8b3a936565"
   dependencies:
     is-number "^2.1.0"
     isobject "^2.0.0"
-    randomatic "^1.1.3"
+    randomatic "^3.0.0"
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
 
@@ -3879,8 +3978,8 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
 flow-parser@^0.*:
-  version "0.70.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.70.0.tgz#9c310187efe4380ba9a251284e9b83b95c49e857"
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.72.0.tgz#6c8041e76ac7d0be1a71ce29c00cd1435fb6013c"
 
 flush-write-stream@^1.0.0:
   version "1.0.3"
@@ -3985,9 +4084,9 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
-fsevents@^1.0.0, fsevents@^1.1.1, fsevents@^1.1.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.0.tgz#e11a5ff285471e4cc43ab9cd09bb7986c565dcdc"
+fsevents@^1.0.0, fsevents@^1.1.2, fsevents@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.3.tgz#08292982e7059f6674c93d8b829c1e8604979ac0"
   dependencies:
     nan "^2.9.2"
     node-pre-gyp "^0.9.0"
@@ -4127,6 +4226,10 @@ glob-stream@^5.3.2:
     to-absolute-glob "^0.1.1"
     unique-stream "^2.0.2"
 
+glob-to-regexp@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
+
 glob@7.1.2, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
@@ -4177,8 +4280,8 @@ globals-docs@^2.3.0:
   resolved "https://registry.yarnpkg.com/globals-docs/-/globals-docs-2.4.0.tgz#f2c647544eb6161c7c38452808e16e693c2dafbb"
 
 globals@^11.0.1, globals@^11.1.0:
-  version "11.4.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-11.4.0.tgz#b85c793349561c16076a3c13549238a27945f1bc"
+  version "11.5.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.5.0.tgz#6bc840de6771173b191f13d3a9c94d441ee92642"
 
 globals@^9.18.0:
   version "9.18.0"
@@ -4205,6 +4308,18 @@ globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+globby@^8.0.0:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-8.0.1.tgz#b5ad48b8aa80b35b814fc1281ecc851f1d2b5b50"
+  dependencies:
+    array-union "^1.0.1"
+    dir-glob "^2.0.0"
+    fast-glob "^2.0.2"
+    glob "^7.1.2"
+    ignore "^3.3.5"
+    pify "^3.0.0"
+    slash "^1.0.0"
+
 got@^7.0.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/got/-/got-7.1.0.tgz#05450fd84094e6bbea56f451a43a9c289166385a"
@@ -4225,8 +4340,8 @@ got@^7.0.0:
     url-to-options "^1.0.1"
 
 got@^8.2.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/got/-/got-8.3.0.tgz#6ba26e75f8a6cc4c6b3eb1fe7ce4fec7abac8533"
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/got/-/got-8.3.1.tgz#093324403d4d955f5a16a7a8d39955d055ae10ed"
   dependencies:
     "@sindresorhus/is" "^0.7.0"
     cacheable-request "^2.1.1"
@@ -4331,6 +4446,10 @@ has-flag@^3.0.0:
 has-symbol-support-x@^1.4.1:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz#1409f98bc00247da45da67cee0a36f282ff26455"
+
+has-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
 
 has-to-string-tag-x@^1.2.0:
   version "1.4.1"
@@ -4564,8 +4683,8 @@ http-errors@~1.6.2:
     statuses ">= 1.4.0 < 2"
 
 http-parser-js@>=0.4.0:
-  version "0.4.11"
-  resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.4.11.tgz#5b720849c650903c27e521633d94696ee95f3529"
+  version "0.4.12"
+  resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.4.12.tgz#b9cfbf4a2cf26f0fc34b10ca1489a27771e3474f"
 
 http-proxy-middleware@~0.18.0:
   version "0.18.0"
@@ -4626,10 +4745,10 @@ husky@0.14.3:
     strip-indent "^2.0.0"
 
 iconv-lite@0.4, iconv-lite@^0.4.17, iconv-lite@^0.4.4, iconv-lite@^0.4.5, iconv-lite@~0.4.13:
-  version "0.4.21"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.21.tgz#c47f8733d02171189ebc4a400f3218d348094798"
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
   dependencies:
-    safer-buffer "^2.1.0"
+    safer-buffer ">= 2.1.2 < 3"
 
 iconv-lite@0.4.19:
   version "0.4.19"
@@ -4659,9 +4778,9 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
-ignore@^3.3.3:
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
+ignore@^3.3.3, ignore@^3.3.5:
+  version "3.3.8"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.8.tgz#3f8e9c35d38708a3a7e0e9abb6c73e7ee7707b2b"
 
 import-local@^1.0.0:
   version "1.0.0"
@@ -5125,8 +5244,8 @@ is-windows@^1.0.1, is-windows@^1.0.2:
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
 is-word-character@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-word-character/-/is-word-character-1.0.1.tgz#5a03fa1ea91ace8a6eb0c7cd770eb86d65c8befb"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-word-character/-/is-word-character-1.0.2.tgz#46a5dac3f2a1840898b91e576cd40d493f3ae553"
 
 is-wsl@^1.1.0:
   version "1.1.0"
@@ -5139,6 +5258,10 @@ isarray@0.0.1:
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+
+isbinaryfile@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-3.0.2.tgz#4a3e974ec0cba9004d3fc6cde7209ea69368a621"
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -5239,7 +5362,7 @@ istanbul-reports@^1.3.0:
   dependencies:
     handlebars "^4.0.3"
 
-istextorbinary@^2.1.0:
+istextorbinary@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/istextorbinary/-/istextorbinary-2.2.1.tgz#a5231a08ef6dd22b268d0895084cf8d58b5bec53"
   dependencies:
@@ -5580,8 +5703,8 @@ jscodeshift@^0.5.0:
     write-file-atomic "^1.2.0"
 
 jsdom@^11.5.1:
-  version "11.8.0"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.8.0.tgz#a52e9a7d2b931284f62c80dad5f17d7390499d8b"
+  version "11.10.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.10.0.tgz#a42cd54e88895dc765f03f15b807a474962ac3b5"
   dependencies:
     abab "^1.0.4"
     acorn "^5.3.0"
@@ -5980,9 +6103,9 @@ lodash@4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
-lodash@^4.11.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0:
-  version "4.17.5"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+lodash@^4.11.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
 log-symbols@^1.0.2:
   version "1.0.2"
@@ -6008,8 +6131,11 @@ loglevel@^1.4.1:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
 
 loglevelnext@^1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/loglevelnext/-/loglevelnext-1.0.4.tgz#0d991d9998180991dac8bd81e73a596a8720a645"
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/loglevelnext/-/loglevelnext-1.0.5.tgz#36fc4f5996d6640f539ff203ba819641680d75a2"
+  dependencies:
+    es6-symbol "^3.1.1"
+    object.assign "^4.1.0"
 
 longest-streak@^2.0.1:
   version "2.0.2"
@@ -6045,8 +6171,8 @@ lowercase-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
 
 lru-cache@^4.0.1, lru-cache@^4.1.1:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.2.tgz#45234b2e6e2f2b33da125624c4664929a0224c3f"
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
@@ -6056,8 +6182,8 @@ macaddress@^0.2.8:
   resolved "https://registry.yarnpkg.com/macaddress/-/macaddress-0.2.8.tgz#5904dc537c39ec6dbefeae902327135fa8511f12"
 
 make-dir@^1.0.0, make-dir@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.2.0.tgz#6d6a49eead4aae296c53bbf3a1a008bd6c89469b"
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
   dependencies:
     pify "^3.0.0"
 
@@ -6096,6 +6222,10 @@ markdown-table@^1.1.0:
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"
+
+math-random@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.1.tgz#8b3aac588b8a66e4975e3cdea67f7bb329601fac"
 
 md5.js@^1.3.4:
   version "1.3.4"
@@ -6159,15 +6289,16 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
 
-mem-fs-editor@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/mem-fs-editor/-/mem-fs-editor-3.0.2.tgz#dd0a6eaf2bb8a6b37740067aa549eb530105af9f"
+mem-fs-editor@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/mem-fs-editor/-/mem-fs-editor-4.0.2.tgz#55a79b1e824da631254c4c95ba6366602c77af90"
   dependencies:
     commondir "^1.0.1"
-    deep-extend "^0.4.0"
-    ejs "^2.3.1"
+    deep-extend "^0.5.1"
+    ejs "^2.5.9"
     glob "^7.0.3"
-    globby "^6.1.0"
+    globby "^8.0.0"
+    isbinaryfile "^3.0.2"
     mkdirp "^0.5.0"
     multimatch "^2.0.0"
     rimraf "^2.2.8"
@@ -6226,6 +6357,10 @@ merge-stream@^1.0.0, merge-stream@^1.0.1:
   dependencies:
     readable-stream "^2.0.1"
 
+merge2@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.2.tgz#03212e3da8d86c4d8523cebd6318193414f94e34"
+
 merge@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
@@ -6252,7 +6387,7 @@ micromatch@^2.1.5, micromatch@^2.3.11, micromatch@^2.3.7:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-micromatch@^3.0.0, micromatch@^3.1.4, micromatch@^3.1.8, micromatch@^3.1.9:
+micromatch@^3.0.0, micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8, micromatch@^3.1.9:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   dependencies:
@@ -6338,8 +6473,8 @@ minimist@~0.0.1:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
 minipass@^2.2.1, minipass@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.2.4.tgz#03c824d84551ec38a8d1bb5bc350a5a30a354a40"
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.0.tgz#2e11b1c46df7fe7f1afbe9a490280add21ffe384"
   dependencies:
     safe-buffer "^5.1.1"
     yallist "^3.0.0"
@@ -6472,8 +6607,8 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
 needle@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.0.tgz#f14efc69cee1024b72c8b21c7bdf94a731dc12fa"
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.1.tgz#b5e325bd3aae8c2678902fa296f729455d1d3a7d"
   dependencies:
     debug "^2.1.2"
     iconv-lite "^0.4.4"
@@ -6512,9 +6647,9 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-forge@0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.1.tgz#9da611ea08982f4b94206b3beb4cc9665f20c300"
+node-forge@0.7.5:
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.5.tgz#6c152c345ce11c52f465c2abd957e8639cd674df"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -6718,7 +6853,7 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-keys@^1.0.8:
+object-keys@^1.0.11, object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
 
@@ -6727,6 +6862,15 @@ object-visit@^1.0.0:
   resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
   dependencies:
     isobject "^3.0.0"
+
+object.assign@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.1"
+    has-symbols "^1.0.0"
+    object-keys "^1.0.11"
 
 object.getownpropertydescriptors@^2.0.3:
   version "2.0.3"
@@ -6966,8 +7110,8 @@ parse-asn1@^5.0.0:
     pbkdf2 "^3.0.3"
 
 parse-entities@^1.0.2:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.1.1.tgz#8112d88471319f27abae4d64964b122fe4e1b890"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.1.2.tgz#9eaf719b29dc3bd62246b4332009072e01527777"
   dependencies:
     character-entities "^1.0.0"
     character-entities-legacy "^1.0.0"
@@ -7166,8 +7310,10 @@ pkg-dir@^2.0.0:
     find-up "^2.1.0"
 
 please-upgrade-node@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.0.1.tgz#0a681f2c18915e5433a5ca2cd94e0b8206a782db"
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.0.2.tgz#7b9eaeca35aa4a43d6ebdfd10616c042f9a83acc"
+  dependencies:
+    semver-compare "^1.0.0"
 
 pluralize@^7.0.0:
   version "7.0.0"
@@ -7428,12 +7574,12 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     supports-color "^3.2.3"
 
 postcss@^6.0.1:
-  version "6.0.21"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.21.tgz#8265662694eddf9e9a5960db6da33c39e4cd069d"
+  version "6.0.22"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.22.tgz#e23b78314905c3b90cbd61702121e7a78848f2a3"
   dependencies:
-    chalk "^2.3.2"
+    chalk "^2.4.1"
     source-map "^0.6.1"
-    supports-color "^5.3.0"
+    supports-color "^5.4.0"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -7477,7 +7623,7 @@ pretty-format@^22.4.3:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
-private@^0.1.6, private@^0.1.7, private@~0.1.5:
+private@^0.1.6, private@^0.1.7, private@^0.1.8, private@~0.1.5:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
@@ -7566,10 +7712,10 @@ pump@^2.0.0, pump@^2.0.1:
     once "^1.3.1"
 
 pumpify@^1.3.3:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/pumpify/-/pumpify-1.4.0.tgz#80b7c5df7e24153d03f0e7ac8a05a5d068bd07fb"
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/pumpify/-/pumpify-1.5.0.tgz#30c905a26c88fa0074927af07256672b474b1c15"
   dependencies:
-    duplexify "^3.5.3"
+    duplexify "^3.6.0"
     inherits "^2.0.3"
     pump "^2.0.0"
 
@@ -7589,9 +7735,13 @@ q@^1.1.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
 
-qs@6.5.1, qs@^6.4.0, qs@~6.5.1:
+qs@6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
+
+qs@^6.4.0, qs@~6.5.1:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
 qs@~2.3.3:
   version "2.3.3"
@@ -7636,12 +7786,13 @@ ramda@0.24.1:
   version "0.24.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.24.1.tgz#c3b7755197f35b8dc3502228262c4c91ddb6b857"
 
-randomatic@^1.1.3:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"
+randomatic@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-3.0.0.tgz#d35490030eb4f7578de292ce6dfb04a91a128923"
   dependencies:
-    is-number "^3.0.0"
-    kind-of "^4.0.0"
+    is-number "^4.0.0"
+    kind-of "^6.0.0"
+    math-random "^1.0.1"
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.0.6"
@@ -7677,10 +7828,10 @@ raw-body@~1.1.0:
     string_decoder "0.10"
 
 rc@^1.1.7:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.6.tgz#eb18989c6d4f4f162c399f79ddd29f3835568092"
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.7.tgz#8a10ca30d588d00464360372b890d06dacd02297"
   dependencies:
-    deep-extend "~0.4.0"
+    deep-extend "^0.5.1"
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
@@ -7803,7 +7954,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.9, readable-stream@^2.3.3, readable-stream@^2.3.5:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.9, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
@@ -8276,6 +8427,10 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
+rsvp@^3.3.3:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
+
 run-async@^2.0.0, run-async@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
@@ -8308,9 +8463,13 @@ rxjs@^5.0.0-beta.11, rxjs@^5.4.2, rxjs@^5.5.2:
   dependencies:
     symbol-observable "1.0.1"
 
-safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+
+safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
 
 safe-json-parse@~1.0.1:
   version "1.0.1"
@@ -8322,15 +8481,16 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-safer-buffer@^2.1.0:
+"safer-buffer@>= 2.1.2 < 3":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
 sane@^2.0.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/sane/-/sane-2.5.0.tgz#6359cd676f5efd9988b264d8ce3b827dd6b27bec"
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/sane/-/sane-2.5.2.tgz#b4dc1861c21b427e929507a3e751e2a2cb8ab3fa"
   dependencies:
     anymatch "^2.0.0"
+    capture-exit "^1.2.0"
     exec-sh "^0.2.0"
     fb-watchman "^2.0.0"
     micromatch "^3.1.4"
@@ -8338,7 +8498,7 @@ sane@^2.0.0:
     walker "~1.0.5"
     watch "~0.18.0"
   optionalDependencies:
-    fsevents "^1.1.1"
+    fsevents "^1.2.3"
 
 sax@^1.2.4, sax@~1.2.1:
   version "1.2.4"
@@ -8366,10 +8526,14 @@ select-hose@^2.0.0:
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
 
 selfsigned@^1.9.1:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.2.tgz#b4449580d99929b65b10a48389301a6592088758"
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.3.tgz#d628ecf9e3735f84e8bafba936b3cf85bea43823"
   dependencies:
-    node-forge "0.7.1"
+    node-forge "0.7.5"
+
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
 
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
   version "5.5.0"
@@ -8491,8 +8655,8 @@ shelljs@^0.7.5:
     rechoir "^0.6.2"
 
 shelljs@^0.8.0:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.1.tgz#729e038c413a2254c4078b95ed46e0397154a9f1"
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.2.tgz#345b7df7763f4c2340d584abb532c5f752ca9e35"
   dependencies:
     glob "^7.0.0"
     interpret "^1.0.0"
@@ -8598,10 +8762,10 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
 
 source-map-resolve@^0.5.0:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.1.tgz#7ad0f593f2281598e854df80f19aae4b92d7a11a"
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
   dependencies:
-    atob "^2.0.0"
+    atob "^2.1.1"
     decode-uri-component "^0.2.0"
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
@@ -8614,9 +8778,10 @@ source-map-support@^0.4.15:
     source-map "^0.5.6"
 
 source-map-support@^0.5.0:
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.4.tgz#54456efa89caa9270af7cd624cc2f123e51fbae8"
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.5.tgz#0d4af9e00493e855402e8ec36ebed2d266fceb90"
   dependencies:
+    buffer-from "^1.0.0"
     source-map "^0.6.0"
 
 source-map-url@^0.4.0:
@@ -8789,12 +8954,12 @@ stream-each@^1.1.0:
     stream-shift "^1.0.0"
 
 stream-http@^2.7.2:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.8.1.tgz#d0441be1a457a73a733a8a7b53570bebd9ef66a4"
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.8.2.tgz#4126e8c6b107004465918aa2fc35549e77402c87"
   dependencies:
     builtin-status-codes "^3.0.0"
     inherits "^2.0.1"
-    readable-stream "^2.3.3"
+    readable-stream "^2.3.6"
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
 
@@ -8861,8 +9026,8 @@ string_decoder@^1.0.0, string_decoder@~1.1.1:
     safe-buffer "~5.1.0"
 
 stringify-entities@^1.0.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/stringify-entities/-/stringify-entities-1.3.1.tgz#b150ec2d72ac4c1b5f324b51fb6b28c9cdff058c"
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/stringify-entities/-/stringify-entities-1.3.2.tgz#a98417e5471fd227b3e45d3db1861c11caf668f7"
   dependencies:
     character-entities-html4 "^1.0.0"
     character-entities-legacy "^1.0.0"
@@ -8974,7 +9139,7 @@ supports-color@^4.0.0, supports-color@^4.1.0, supports-color@^4.2.1:
   dependencies:
     has-flag "^2.0.0"
 
-supports-color@^5.1.0, supports-color@^5.3.0:
+supports-color@^5.1.0, supports-color@^5.3.0, supports-color@^5.4.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
   dependencies:
@@ -9024,15 +9189,15 @@ tapable@^1.0.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.0.0.tgz#cbb639d9002eed9c6b5975eb20598d7936f1f9f2"
 
 tar@^4:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.1.tgz#b25d5a8470c976fd7a9a8a350f42c59e9fa81749"
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.2.tgz#60685211ba46b38847b1ae7ee1a24d744a2cd462"
   dependencies:
     chownr "^1.0.1"
     fs-minipass "^1.2.5"
     minipass "^2.2.4"
     minizlib "^1.1.0"
     mkdirp "^0.5.0"
-    safe-buffer "^5.1.1"
+    safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
 temp@^0.8.1:
@@ -9175,8 +9340,8 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     safe-regex "^1.1.0"
 
 toposort@^1.0.0:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.6.tgz#c31748e55d210effc00fdcdc7d6e68d7d7bb9cec"
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.7.tgz#2e68442d9f64ec720b8cc89e6443ac6caa950029"
 
 tough-cookie@>=2.3.3, tough-cookie@^2.3.3, tough-cookie@~2.3.0, tough-cookie@~2.3.3:
   version "2.3.4"
@@ -9184,7 +9349,7 @@ tough-cookie@>=2.3.3, tough-cookie@^2.3.3, tough-cookie@~2.3.0, tough-cookie@~2.
   dependencies:
     punycode "^1.4.1"
 
-tr46@^1.0.0:
+tr46@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
   dependencies:
@@ -9203,8 +9368,8 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
 trim-trailing-lines@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.0.tgz#7aefbb7808df9d669f6da2e438cac8c46ada7684"
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.1.tgz#e0ec0810fd3c3f1730516b45f49083caaf2774d9"
 
 trim@0.0.1:
   version "0.0.1"
@@ -9246,8 +9411,8 @@ typedarray@^0.0.6, typedarray@~0.0.5:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
 ua-parser-js@^0.7.9:
-  version "0.7.17"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
+  version "0.7.18"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"
 
 uglify-es@^3.3.4:
   version "3.3.9"
@@ -9257,8 +9422,8 @@ uglify-es@^3.3.4:
     source-map "~0.6.1"
 
 uglify-js@3.3.x:
-  version "3.3.22"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.3.22.tgz#e5f0e50ddd386b7e35b728b51600bf7a7ad0b0dc"
+  version "3.3.24"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.3.24.tgz#abeae7690c602ebd006f4567387a0c0c333bdc0d"
   dependencies:
     commander "~2.15.0"
     source-map "~0.6.1"
@@ -9306,22 +9471,21 @@ underscore@~1.6.0:
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
 
 unherit@^1.0.4:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.0.tgz#6b9aaedfbf73df1756ad9e316dd981885840cd7d"
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.1.tgz#132748da3e88eab767e08fabfbb89c5e9d28628c"
   dependencies:
     inherits "^2.0.1"
     xtend "^4.0.1"
 
 unified@^6.0.0:
-  version "6.1.6"
-  resolved "https://registry.yarnpkg.com/unified/-/unified-6.1.6.tgz#5ea7f807a0898f1f8acdeefe5f25faa010cc42b1"
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-6.2.0.tgz#7fbd630f719126d67d40c644b7e3f617035f6dba"
   dependencies:
     bail "^1.0.0"
     extend "^3.0.0"
     is-plain-obj "^1.1.0"
     trough "^1.0.0"
     vfile "^2.0.0"
-    x-is-function "^1.0.4"
     x-is-string "^0.1.0"
 
 union-value@^1.0.0:
@@ -9379,36 +9543,36 @@ unist-builder@^1.0.0, unist-builder@^1.0.1:
     object-assign "^4.1.0"
 
 unist-util-generated@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/unist-util-generated/-/unist-util-generated-1.1.1.tgz#99f16c78959ac854dee7c615c291924c8bf4de7f"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-generated/-/unist-util-generated-1.1.2.tgz#8b993f9239d8e560be6ee6e91c3f7b7208e5ce25"
 
 unist-util-is@^2.0.0, unist-util-is@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-2.1.1.tgz#0c312629e3f960c66e931e812d3d80e77010947b"
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-2.1.2.tgz#1193fa8f2bfbbb82150633f3a8d2eb9a1c1d55db"
 
 unist-util-modify-children@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/unist-util-modify-children/-/unist-util-modify-children-1.1.1.tgz#66d7e6a449e6f67220b976ab3cb8b5ebac39e51d"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-modify-children/-/unist-util-modify-children-1.1.2.tgz#c7f1b91712554ee59c47a05b551ed3e052a4e2d1"
   dependencies:
     array-iterate "^1.0.0"
 
 unist-util-position@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/unist-util-position/-/unist-util-position-3.0.0.tgz#e6e1e03eeeb81c5e1afe553e8d4adfbd7c0d8f82"
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/unist-util-position/-/unist-util-position-3.0.1.tgz#8e220c24658239bf7ddafada5725ed0ea1ebbc26"
 
 unist-util-remove-position@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.1.tgz#5a85c1555fc1ba0c101b86707d15e50fa4c871bb"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.2.tgz#86b5dad104d0bbfbeb1db5f5c92f3570575c12cb"
   dependencies:
     unist-util-visit "^1.1.0"
 
 unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.1.tgz#3ccbdc53679eed6ecf3777dd7f5e3229c1b6aa3c"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz#3f37fcf351279dcbca7480ab5889bb8a832ee1c6"
 
 unist-util-visit@^1.0.0, unist-util-visit@^1.0.1, unist-util-visit@^1.1.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.3.0.tgz#41ca7c82981fd1ce6c762aac397fc24e35711444"
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.3.1.tgz#c019ac9337a62486be58531bc27e7499ae7d55c7"
   dependencies:
     unist-util-is "^2.1.1"
 
@@ -9432,16 +9596,16 @@ untildify@^3.0.2:
   resolved "https://registry.yarnpkg.com/untildify/-/untildify-3.0.2.tgz#7f1f302055b3fea0f3e81dc78eb36766cb65e3f1"
 
 upath@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/upath/-/upath-1.0.4.tgz#ee2321ba0a786c50973db043a50b7bcba822361d"
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.0.5.tgz#02cab9ecebe95bbec6d5fc2566325725ab6d1a73"
 
 upper-case@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
 
-uri-js@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-3.0.2.tgz#f90b858507f81dea4dcfbb3c4c3dbfa2b557faaa"
+uri-js@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.1.tgz#4595a80a51f356164e22970df64c7abd6ade9850"
   dependencies:
     punycode "^2.1.0"
 
@@ -9575,12 +9739,12 @@ verror@1.10.0:
     extsprintf "^1.2.0"
 
 vfile-location@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.2.tgz#d3675c59c877498e492b4756ff65e4af1a752255"
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.3.tgz#083ba80e50968e8d420be49dd1ea9a992131df77"
 
 vfile-message@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-1.0.0.tgz#a6adb0474ea400fa25d929f1d673abea6a17e359"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-1.0.1.tgz#51a2ccd8a6b97a7980bb34efb9ebde9632e93677"
   dependencies:
     unist-util-stringify-position "^1.1.1"
 
@@ -9595,12 +9759,12 @@ vfile-reporter@^4.0.0:
     vfile-statistics "^1.1.0"
 
 vfile-sort@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/vfile-sort/-/vfile-sort-2.1.0.tgz#49501c9e8bbe5adff2e9b3a7671ee1b1e20c5210"
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/vfile-sort/-/vfile-sort-2.1.1.tgz#03acdc8a4d7870ecf0e35499f095ddd9d14cbc41"
 
 vfile-statistics@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/vfile-statistics/-/vfile-statistics-1.1.0.tgz#02104c60fdeed1d11b1f73ad65330b7634b3d895"
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/vfile-statistics/-/vfile-statistics-1.1.1.tgz#a22fd4eb844c9eaddd781ad3b3246db88375e2e3"
 
 vfile@^2.0.0:
   version "2.3.0"
@@ -9689,8 +9853,8 @@ watch@~0.18.0:
     minimist "^1.2.0"
 
 watchpack@^1.4.0, watchpack@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.5.0.tgz#231e783af830a22f8966f65c4c4bacc814072eed"
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.6.0.tgz#4bc12c2ebe8aa277a71f1d3f14d685c7b446cd00"
   dependencies:
     chokidar "^2.0.2"
     graceful-fs "^4.1.2"
@@ -9702,7 +9866,7 @@ wbuf@^1.1.0, wbuf@^1.7.2:
   dependencies:
     minimalistic-assert "^1.0.0"
 
-webidl-conversions@^4.0.1, webidl-conversions@^4.0.2:
+webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
 
@@ -9893,12 +10057,12 @@ whatwg-mimetype@^2.0.0, whatwg-mimetype@^2.1.0:
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz#f0f21d76cbba72362eb609dbed2a30cd17fcc7d4"
 
 whatwg-url@^6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.4.0.tgz#08fdf2b9e872783a7a1f6216260a1d66cc722e08"
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.4.1.tgz#fdb94b440fd4ad836202c16e9737d511f012fd67"
   dependencies:
     lodash.sortby "^4.7.0"
-    tr46 "^1.0.0"
-    webidl-conversions "^4.0.1"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
 
 whet.extend@~0.9.9:
   version "0.9.9"
@@ -9985,10 +10149,6 @@ ws@^4.0.0:
   dependencies:
     async-limiter "~1.0.0"
     safe-buffer "~5.1.0"
-
-x-is-function@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/x-is-function/-/x-is-function-1.0.4.tgz#5d294dc3d268cbdd062580e0c5df77a391d1fa1e"
 
 x-is-string@^0.1.0:
   version "0.1.0"
@@ -10163,24 +10323,24 @@ yeoman-environment@^2.0.0, yeoman-environment@^2.0.5:
     untildify "^3.0.2"
 
 yeoman-generator@^2.0.3:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/yeoman-generator/-/yeoman-generator-2.0.4.tgz#c1c51580ab88506233dd6e837a4bbf8a8e34c9a6"
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/yeoman-generator/-/yeoman-generator-2.0.5.tgz#57b0b3474701293cc9ec965288f3400b00887c81"
   dependencies:
     async "^2.6.0"
     chalk "^2.3.0"
     cli-table "^0.3.1"
-    cross-spawn "^5.1.0"
+    cross-spawn "^6.0.5"
     dargs "^5.1.0"
-    dateformat "^3.0.2"
+    dateformat "^3.0.3"
     debug "^3.1.0"
     detect-conflict "^1.0.0"
     error "^7.0.2"
     find-up "^2.1.0"
     github-username "^4.0.0"
-    istextorbinary "^2.1.0"
-    lodash "^4.17.4"
+    istextorbinary "^2.2.1"
+    lodash "^4.17.10"
     make-dir "^1.1.0"
-    mem-fs-editor "^3.0.2"
+    mem-fs-editor "^4.0.0"
     minimist "^1.2.0"
     pretty-bytes "^4.0.2"
     read-chunk "^2.1.0"


### PR DESCRIPTION
Fix https://github.com/danielcaldas/react-d3-graph/issues/68

Since npm v3 `peerDependencies` are not installed automatically, that is why they were also added to the `devDependencies` because they are required for development purposes (can't run dev sandbox without it)

[About Peer Dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/)