### PR TITLE
Customize color for a link

### DIFF
--- a/src/components/graph/graph.helper.js
+++ b/src/components/graph/graph.helper.js
@@ -176,8 +176,7 @@ function _validateGraphData(data) {
 
 /**
  * Build some Link properties based on given parameters.
- * @param  {string} source - the id of the source node (from).
- * @param  {string} target - the id of the target node (to).
+ * @param  {Object} link - the link object for which we will generate properties.
  * @param  {Object.<string, Object>} nodes - same as {@link #buildGraph|nodes in buildGraph}.
  * @param  {Object.<string, Object>} links - same as {@link #buildGraph|links in buildGraph}.
  * @param  {Object} config - same as {@link #buildGraph|config in buildGraph}.
@@ -188,17 +187,9 @@ function _validateGraphData(data) {
  * @returns {Object} returns an object that aggregates all props for creating respective Link component instance.
  * @memberof Graph/helper
  */
-function buildLinkProps(
-    source,
-    target,
-    nodes,
-    links,
-    config,
-    linkCallbacks,
-    highlightedNode,
-    highlightedLink,
-    transform
-) {
+function buildLinkProps(link, nodes, links, config, linkCallbacks, highlightedNode, highlightedLink, transform) {
+    const { source, target } = link;
+
     const x1 = (nodes[source] && nodes[source].x) || 0;
     const y1 = (nodes[source] && nodes[source].y) || 0;
     const x2 = (nodes[target] && nodes[target].x) || 0;
@@ -230,7 +221,7 @@ function buildLinkProps(
         opacity = highlight ? config.link.opacity : config.highlightOpacity;
     }
 
-    let stroke = config.link.color;
+    let stroke = link.color || config.link.color;
 
     if (highlight) {
         stroke = config.link.highlightColor === CONST.KEYWORDS.SAME ? config.link.color : config.link.highlightColor;

--- a/src/components/graph/graph.renderer.jsx
+++ b/src/components/graph/graph.renderer.jsx
@@ -32,8 +32,7 @@ function _buildLinks(nodes, links, linksMatrix, config, linkCallbacks, highlight
         const targetId = target.id || target;
         const key = `${sourceId}${CONST.COORDS_SEPARATOR}${targetId}`;
         const props = buildLinkProps(
-            `${sourceId}`,
-            `${targetId}`,
+            { ...link, source: `${sourceId}`, target: `${targetId}` },
             nodes,
             linksMatrix,
             config,

--- a/test/component/graph/graph.helper.test.js
+++ b/test/component/graph/graph.helper.test.js
@@ -20,6 +20,55 @@ describe('Graph Helper', () => {
         utils.throwErr = jest.fn();
     });
 
+    describe('#buildLinkProps', () => {
+        let that = {};
+
+        beforeAll(() => {
+            const linkConfig = Object.assign({}, config.link);
+
+            that = {
+                config: { link: linkConfig },
+                link: { source: 'source', target: 'target' }
+            };
+        });
+
+        describe('when building props for a link', () => {
+            describe('and no custom color is set', () => {
+                test('should return default color defined in link config', () => {
+                    const props = graphHelper.buildLinkProps(
+                        that.link,
+                        {},
+                        {},
+                        that.config,
+                        [],
+                        undefined,
+                        undefined,
+                        1
+                    );
+
+                    expect(props.stroke).toEqual(that.config.link.color);
+                });
+            });
+
+            describe('and custom color is set to green', () => {
+                test('should return green color in the props', () => {
+                    const props = graphHelper.buildLinkProps(
+                        { ...that.link, color: 'green' },
+                        {},
+                        {},
+                        that.config,
+                        [],
+                        undefined,
+                        undefined,
+                        1
+                    );
+
+                    expect(props.stroke).toEqual('green');
+                });
+            });
+        });
+    });
+
     describe('#buildNodeProps', () => {
         let that = {};
 


### PR DESCRIPTION
I was planning on using your library for a project I'm currently working on, but I needed to be able to customize the color for each link separately. I saw a recently closed issue requesting this feature (#71) and that there was no one who had offered to implement it yet, so I decided to give it a go.  

This set of changes is the result, and it makes it possible to set a custom color for single link when defining its data:

`{ source: 'A', target: 'B', color: 'orange' }` 

A couple of tests were also included to ensure the behaviour is as expected:

- If a custom color was set for the link, the stroke value for the line to draw must be equal to said color.
- If no custom color was provided, the stroke value should match the one defined in the link configuration object. 

PS: Very beautifully written and documented code, it was a real joy to work with. Congratulations and thanks for your hard work! 😉  