### PR TITLE
fix: Graph fails to render without config prop

### DIFF
--- a/src/components/graph/Graph.jsx
+++ b/src/components/graph/Graph.jsx
@@ -310,15 +310,17 @@ export default class Graph extends React.Component {
                 nodes: this.state.nodesInputSnapshot,
                 links: this.state.linksInputSnapshot
             });
-        const configUpdated =
-            !utils.isObjectEmpty(nextProps.config) && !utils.isDeepEqual(nextProps.config, this.state.config);
         const state = newGraphElements ? graphHelper.initializeGraphState(nextProps, this.state) : this.state;
-        const config = configUpdated ? utils.merge(DEFAULT_CONFIG, nextProps.config || {}) : this.state.config;
+
+        const newConfig = nextProps.config || {};
+        const configUpdated =
+            newConfig && !utils.isObjectEmpty(newConfig) && !utils.isDeepEqual(newConfig, this.state.config);
+        const config = configUpdated ? utils.merge(DEFAULT_CONFIG, newConfig) : this.state.config;
 
         // in order to properly update graph data we need to pause eventual d3 ongoing animations
         newGraphElements && this.pauseSimulation();
 
-        const transform = nextProps.config.panAndZoom !== this.state.config.panAndZoom ? 1 : this.state.transform;
+        const transform = newConfig.panAndZoom !== this.state.config.panAndZoom ? 1 : this.state.transform;
 
         this.setState({
             ...state,


### PR DESCRIPTION
When the user didn't add the 'config' prop to the 'Graph' component (which should be possible, as it's an optional field), the graph failed to render whenever its data changed.

The component would work the first time around, but when it received new data, it threw an error as described [in this issue](https://github.com/danielcaldas/react-d3-graph/issues/81) and the view would not update.

The root of the problem was located in the `componentWillReceiveProps` method of the `Graph` component. When defining the constants `configUpdated` and `transform`, the case in which `newProps.config` was set to either null or undefined was not being considered. This caused errors when calling `isDeepEqual` and also when trying to get the `panAndZoom` property during `transform` initialization.