### PR TITLE
Focus view on a node

### DIFF
--- a/sandbox/Sandbox.jsx
+++ b/sandbox/Sandbox.jsx
@@ -50,7 +50,10 @@ export default class Sandbox extends React.Component {
         };
     }
 
-    onClickNode = id => window.alert(`Clicked node ${id}`);
+    onClickNode = id => {
+        window.alert(`Clicked node ${id}`);
+        this.setState({ focusedNodeId: this.state.focusedNodeId !== id ? id : null });
+    };
 
     onClickLink = (source, target) => window.alert(`Clicked link between ${source} and ${target}`);
 
@@ -298,7 +301,8 @@ export default class Sandbox extends React.Component {
             onMouseOverNode: this.onMouseOverNode,
             onMouseOutNode: this.onMouseOutNode,
             onMouseOverLink: this.onMouseOverLink,
-            onMouseOutLink: this.onMouseOutLink
+            onMouseOutLink: this.onMouseOutLink,
+            focusedNodeId: this.state.focusedNodeId
         };
 
         if (this.state.fullscreen) {

--- a/src/components/graph/Graph.jsx
+++ b/src/components/graph/Graph.jsx
@@ -379,6 +379,31 @@ export default class Graph extends React.Component {
         this.props.onClickNode && this.props.onClickNode(clickedNodeId);
     };
 
+    /**
+     * Returns the transformation to apply in order to center the graph on the
+     * selected node.
+     * @param   {number} nodeId - node to focus the graph view on.
+     * @returns {string} transform rule to apply.
+     */
+    getCenterAndZoomTransformation = nodeId => {
+        const node = this.state.d3Nodes.find(node => node.id === nodeId);
+
+        if (!node) {
+            console.warn(`There isn't a node with id ${nodeId}.`);
+            return;
+        }
+
+        console.log(`Graph will focus on node ${nodeId}...`);
+        const { width, height, focusZoom } = this.state.config;
+
+        // TODO: ensure that focusZoom is between minZoom and maxZoom
+        return `
+            translate(${width / 2}, ${height / 2})
+            scale(${focusZoom})
+            translate(${-node.x}, ${-node.y})
+        `;
+    };
+
     render() {
         const { nodes, links } = graphRenderer.buildGraph(
             this.state.nodes,
@@ -405,10 +430,16 @@ export default class Graph extends React.Component {
             width: this.state.config.width
         };
 
+        const { focusedNodeId } = this.props;
+        const containerProps = {
+            style: { transitionDuration: '.75s' },
+            transform: focusedNodeId ? this.getCenterAndZoomTransformation(focusedNodeId) : null
+        };
+
         return (
             <div id={`${this.state.id}-${CONST.GRAPH_WRAPPER_ID}`}>
                 <svg style={svgStyle}>
-                    <g id={`${this.state.id}-${CONST.GRAPH_CONTAINER_ID}`}>
+                    <g id={`${this.state.id}-${CONST.GRAPH_CONTAINER_ID}`} {...containerProps}>
                         {links}
                         {nodes}
                     </g>

--- a/src/components/graph/Graph.jsx
+++ b/src/components/graph/Graph.jsx
@@ -396,7 +396,6 @@ export default class Graph extends React.Component {
         console.log(`Graph will focus on node ${nodeId}...`);
         const { width, height, focusZoom } = this.state.config;
 
-        // TODO: ensure that focusZoom is between minZoom and maxZoom
         return `
             translate(${width / 2}, ${height / 2})
             scale(${focusZoom})

--- a/src/components/graph/graph.config.js
+++ b/src/components/graph/graph.config.js
@@ -46,6 +46,7 @@
  * the value the more the less highlighted nodes will be visible (related to *nodeHighlightBehavior*).
  * @param {number} [maxZoom=8] - max zoom that can be performed against the graph.
  * @param {number} [minZoom=0.1] - min zoom that can be performed against the graph.
+ * @param {number} [focusZoom=1] - zoom that will be applied when the graph view is focused in a node.
  * @param {boolean} [panAndZoom=false] - 🚅🚅🚅 pan and zoom effect when performing zoom in the graph,
  * a similar functionality may be consulted {@link https://bl.ocks.org/mbostock/2a39a768b1d4bc00a09650edef75ad39|here}.
  * @param {boolean} [staticGraph=false] - when setting this value to true the graph will be completely static, thus
@@ -146,6 +147,7 @@ export default {
     linkHighlightBehavior: false,
     maxZoom: 8,
     minZoom: 0.1,
+    focusZoom: 1,
     nodeHighlightBehavior: false,
     panAndZoom: false,
     staticGraph: false,

--- a/src/components/graph/graph.helper.js
+++ b/src/components/graph/graph.helper.js
@@ -362,6 +362,10 @@ function initializeGraphState({ data, id, config }, state) {
     const formatedId = id.replace(/ /g, '_');
     const simulation = _createForceSimulation(newConfig.width, newConfig.height);
 
+    // ensure focus zoom is between minZoom and maxZoom
+    const { minZoom, maxZoom, focusZoom } = newConfig;
+    newConfig.focusZoom = focusZoom > maxZoom ? maxZoom : focusZoom < minZoom ? minZoom : focusZoom;
+
     return {
         id: formatedId,
         config: newConfig,


### PR DESCRIPTION
The `Graph` component can receive a `focusedNodeId` prop with the id of an existing node. When that value is set, the node appear on the center of the visible part of the graph. 

By default, the graph will be centered on the selected node, but the graph scale will not change. However, there's a new `focusZoom` property that can be added to the `config` object. If that property is set to a value different from 1, the selected zoom will be applied whenever the graph focuses on a node. 

The sandbox example has been updated to preview this new feature. When the user clicks on a node, it will immediatly become the focused node. 