### PR TITLE
Fix/defensive code for curve types

### DIFF
--- a/sandbox/utils.js
+++ b/sandbox/utils.js
@@ -1,11 +1,26 @@
 /*eslint require-jsdoc: 0, valid-jsdoc: 0, no-undef: 0, no-empty: 0, no-console: 0*/
 import queryString from 'query-string';
+import { LINE_TYPES } from '../src/components/link/link.const';
 
 /**
  * This two functions generate the react-jsonschema-form
  * schema from some passed graph configuration.
  */
 function formMap(k, v) {
+    // customized props
+    switch (k) {
+        case 'link.type': {
+            return {
+                type: 'array',
+                title: 'link.type',
+                items: {
+                    enum: Object.keys(LINE_TYPES)
+                },
+                uniqueItems: true
+            };
+        }
+    }
+
     return {
         title: k,
         type: typeof v,

--- a/src/components/link/link.helper.js
+++ b/src/components/link/link.helper.js
@@ -71,7 +71,8 @@ function getRadiusStrategy(type) {
 function buildLinkPathDefinition({ source = {}, target = {} }, type = LINE_TYPES.STRAIGHT) {
     const { x: sx, y: sy } = source;
     const { x: tx, y: ty } = target;
-    const radius = getRadiusStrategy(type)(sx, sy, tx, ty);
+    const validType = LINE_TYPES[type] || LINE_TYPES.STRAIGHT;
+    const radius = getRadiusStrategy(validType)(sx, sy, tx, ty);
 
     return `M${sx},${sy}A${radius},${radius} 0 0,1 ${tx},${ty}`;
 }


### PR DESCRIPTION
- Add fallback for invalid (but existent) link types
- Small experiment on the sandbox, exploring capabilities of `react-jsonschema-form` in order to customize `link.type` selection