### PR TITLE
Remove snapshoot structures for nodes and links

### DIFF
--- a/src/components/graph/graph.helper.js
+++ b/src/components/graph/graph.helper.js
@@ -423,8 +423,6 @@ function initializeGraphState({ data, id, config }, state) {
     _validateGraphData(data);
 
     let graph;
-    const nodesInputSnapshot = data.nodes.map(n => Object.assign({}, n));
-    const linksInputSnapshot = data.links.map(l => Object.assign({}, l));
 
     if (state && state.nodes) {
         graph = {
@@ -455,10 +453,8 @@ function initializeGraphState({ data, id, config }, state) {
         config: newConfig,
         links,
         d3Links,
-        linksInputSnapshot,
         nodes,
         d3Nodes,
-        nodesInputSnapshot,
         highlightedNode: '',
         simulation,
         newGraphElements: false,

--- a/test/component/graph/graph.helper.test.js
+++ b/test/component/graph/graph.helper.test.js
@@ -434,16 +434,6 @@ describe('Graph Helper', () => {
                             A: 1
                         }
                     },
-                    linksInputSnapshot: [
-                        {
-                            source: 'A',
-                            target: 'B'
-                        },
-                        {
-                            source: 'C',
-                            target: 'A'
-                        }
-                    ],
                     newGraphElements: false,
                     nodes: {
                         A: {
@@ -465,17 +455,6 @@ describe('Graph Helper', () => {
                             y: 0
                         }
                     },
-                    nodesInputSnapshot: [
-                        {
-                            id: 'A'
-                        },
-                        {
-                            id: 'B'
-                        },
-                        {
-                            id: 'C'
-                        }
-                    ],
                     simulation: {
                         force: forceStub
                     },


### PR DESCRIPTION
- `nodesInputSnapshot` and `linksInputSnapshot` not in use anymore