### PR TITLE
Global `viewGenerator` included in default config object

### DIFF
--- a/sandbox/utils.js
+++ b/sandbox/utils.js
@@ -32,7 +32,9 @@ function generateFormSchema(o, rootSpreadProp, accum = {}) {
     for (let k of Object.keys(o)) {
         const kk = rootSpreadProp ? `${rootSpreadProp}.${k}` : k;
 
-        typeof o[k] === 'object' ? generateFormSchema(o[kk], kk, accum) : (accum[kk] = formMap(kk, o[k]));
+        if (o[k] !== undefined && o[k] !== null && typeof o[k] !== 'function') {
+            typeof o[k] === 'object' ? generateFormSchema(o[kk], kk, accum) : (accum[kk] = formMap(kk, o[k]));
+        }
     }
 
     return accum;

--- a/src/components/graph/graph.config.js
+++ b/src/components/graph/graph.config.js
@@ -113,7 +113,7 @@
  *   - 'wye'
  *
  * **[note]** react-d3-graph will map this values to [d3 symbols](https://github.com/d3/d3-shape#symbols)
- * @param {Function} [node.viewGenerator=undefined] - 🔍🔍🔍 function that receives a node and returns a JSX view.
+ * @param {Function} [node.viewGenerator=null] - 🔍🔍🔍 function that receives a node and returns a JSX view.
  * <br/>
  * @param {Object} link link object is explained in the next section. ⬇️
  * <h2 id="config-link"><a href="#config-link">#</a> Link level configurations</h2>
@@ -194,7 +194,8 @@ export default {
         strokeColor: 'none',
         strokeWidth: 1.5,
         svg: '',
-        symbolType: 'circle'
+        symbolType: 'circle',
+        viewGenerator: null
     },
     link: {
         color: '#d3d3d3',

--- a/test/component/graph/graph.helper.test.js
+++ b/test/component/graph/graph.helper.test.js
@@ -124,7 +124,7 @@ describe('Graph Helper', () => {
                     strokeWidth: 2,
                     svg: 'file.svg',
                     type: 'circle',
-                    viewGenerator: undefined,
+                    viewGenerator: null,
                     overrideGlobalViewGenerator: undefined
                 });
             });
@@ -170,7 +170,7 @@ describe('Graph Helper', () => {
                         strokeWidth: 1.5,
                         svg: 'file.svg',
                         type: 'circle',
-                        viewGenerator: undefined,
+                        viewGenerator: null,
                         overrideGlobalViewGenerator: undefined
                     });
                 });
@@ -215,7 +215,7 @@ describe('Graph Helper', () => {
                         strokeWidth: 1.5,
                         svg: 'file.svg',
                         type: 'circle',
-                        viewGenerator: undefined,
+                        viewGenerator: null,
                         overrideGlobalViewGenerator: undefined
                     });
                 });


### PR DESCRIPTION
As described in #130 , the `viewGenerator` function value was been ignored when it was set in the `Graph` config object. This was probably due to the fact that the `config` object is not stored as it comes, since its properties are filtered to match only those which exists in the default config object.

This PR addresses this issue, and now it's possible to successfully add a high level `viewGenerator` function without having to override its value for every node in the graph.