### PR TITLE
Update webpack-dev-server and react-dom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -665,6 +665,12 @@
             "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
             "dev": true
         },
+        "ansi-colors": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+            "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+            "dev": true
+        },
         "ansi-escapes": {
             "version": "1.4.0",
             "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
@@ -778,12 +784,6 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
             "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
-            "dev": true
-        },
-        "array-find-index": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-            "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
             "dev": true
         },
         "array-flatten": {
@@ -2907,24 +2907,6 @@
             "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
             "dev": true
         },
-        "camelcase-keys": {
-            "version": "2.1.0",
-            "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-            "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-            "dev": true,
-            "requires": {
-                "camelcase": "2.1.1",
-                "map-obj": "1.0.1"
-            },
-            "dependencies": {
-                "camelcase": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-                    "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-                    "dev": true
-                }
-            }
-        },
         "caniuse-lite": {
             "version": "1.0.30000923",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000923.tgz",
@@ -3446,9 +3428,9 @@
             }
         },
         "connect-history-api-fallback": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
-            "integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo=",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+            "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
             "dev": true
         },
         "console-browserify": {
@@ -3764,15 +3746,6 @@
             "dev": true,
             "requires": {
                 "cssom": "0.3.4"
-            }
-        },
-        "currently-unhandled": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-            "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-            "dev": true,
-            "requires": {
-                "array-find-index": "1.0.2"
             }
         },
         "cyclist": {
@@ -4332,6 +4305,46 @@
             "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
             "dev": true
         },
+        "default-gateway": {
+            "version": "2.7.2",
+            "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.7.2.tgz",
+            "integrity": "sha512-lAc4i9QJR0YHSDFdzeBQKfZ1SRDG3hsJNEkrpcZa8QhBfidLAilT60BDEIVUUGqosFp425KOgB3uYqcnQrWafQ==",
+            "dev": true,
+            "requires": {
+                "execa": "0.10.0",
+                "ip-regex": "2.1.0"
+            },
+            "dependencies": {
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                    "dev": true,
+                    "requires": {
+                        "nice-try": "1.0.5",
+                        "path-key": "2.0.1",
+                        "semver": "5.6.0",
+                        "shebang-command": "1.2.0",
+                        "which": "1.3.1"
+                    }
+                },
+                "execa": {
+                    "version": "0.10.0",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+                    "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "6.0.5",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
+                    }
+                }
+            }
+        },
         "default-require-extensions": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
@@ -4430,7 +4443,7 @@
             "dependencies": {
                 "globby": {
                     "version": "6.1.0",
-                    "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
                     "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
                     "dev": true,
                     "requires": {
@@ -4443,7 +4456,7 @@
                     "dependencies": {
                         "pify": {
                             "version": "2.3.0",
-                            "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                             "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                             "dev": true
                         }
@@ -5789,9 +5802,9 @@
             "dev": true
         },
         "eventsource": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
-            "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.7.tgz",
+            "integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
             "dev": true,
             "requires": {
                 "original": "1.0.2"
@@ -7127,12 +7140,6 @@
             "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
             "dev": true
         },
-        "get-stdin": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-            "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-            "dev": true
-        },
         "get-stream": {
             "version": "3.0.0",
             "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
@@ -7523,9 +7530,9 @@
             }
         },
         "handle-thing": {
-            "version": "1.2.5",
-            "resolved": "http://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
-            "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
+            "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==",
             "dev": true
         },
         "handlebars": {
@@ -8005,7 +8012,7 @@
         },
         "http-proxy-middleware": {
             "version": "0.18.0",
-            "resolved": "http://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
             "integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
             "dev": true,
             "requires": {
@@ -8280,12 +8287,13 @@
             }
         },
         "internal-ip": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
-            "integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-3.0.1.tgz",
+            "integrity": "sha512-NXXgESC2nNVtU+pqmC9e6R8B1GpKxzsAQhffvh5AL79qKnodd+L7tnEQmTiUAVngqLalPbSqRA7XGIEL5nCd0Q==",
             "dev": true,
             "requires": {
-                "meow": "3.7.0"
+                "default-gateway": "2.7.2",
+                "ipaddr.js": "1.8.0"
             }
         },
         "interpret": {
@@ -8323,6 +8331,12 @@
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
             "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+            "dev": true
+        },
+        "ip-regex": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+            "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
             "dev": true
         },
         "ipaddr.js": {
@@ -11621,16 +11635,6 @@
             "integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=",
             "dev": true
         },
-        "loglevelnext": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/loglevelnext/-/loglevelnext-1.0.5.tgz",
-            "integrity": "sha512-V/73qkPuJmx4BcBF19xPBr+0ZRVBhc4POxvZTZdMeXpJ4NItXSJ/MSwuFT0kQJlCbXvdlZoQQ/418bS1y9Jh6A==",
-            "dev": true,
-            "requires": {
-                "es6-symbol": "3.1.1",
-                "object.assign": "4.1.0"
-            }
-        },
         "longest": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
@@ -11650,16 +11654,6 @@
             "dev": true,
             "requires": {
                 "js-tokens": "3.0.2"
-            }
-        },
-        "loud-rejection": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-            "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-            "dev": true,
-            "requires": {
-                "currently-unhandled": "0.4.1",
-                "signal-exit": "3.0.2"
             }
         },
         "lower-case": {
@@ -11702,16 +11696,19 @@
                 "tmpl": "1.0.4"
             }
         },
+        "map-age-cleaner": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+            "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+            "dev": true,
+            "requires": {
+                "p-defer": "1.0.0"
+            }
+        },
         "map-cache": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
             "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-            "dev": true
-        },
-        "map-obj": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-            "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
             "dev": true
         },
         "map-stream": {
@@ -11961,111 +11958,6 @@
                     "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                     "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                     "dev": true
-                }
-            }
-        },
-        "meow": {
-            "version": "3.7.0",
-            "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-            "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-            "dev": true,
-            "requires": {
-                "camelcase-keys": "2.1.0",
-                "decamelize": "1.2.0",
-                "loud-rejection": "1.6.0",
-                "map-obj": "1.0.1",
-                "minimist": "1.2.0",
-                "normalize-package-data": "2.4.0",
-                "object-assign": "4.1.1",
-                "read-pkg-up": "1.0.1",
-                "redent": "1.0.0",
-                "trim-newlines": "1.0.0"
-            },
-            "dependencies": {
-                "find-up": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                    "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-                    "dev": true,
-                    "requires": {
-                        "path-exists": "2.1.0",
-                        "pinkie-promise": "2.0.1"
-                    }
-                },
-                "load-json-file": {
-                    "version": "1.1.0",
-                    "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                    "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "4.1.15",
-                        "parse-json": "2.2.0",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1",
-                        "strip-bom": "2.0.0"
-                    }
-                },
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
-                },
-                "path-exists": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-                    "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-                    "dev": true,
-                    "requires": {
-                        "pinkie-promise": "2.0.1"
-                    }
-                },
-                "path-type": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-                    "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "4.1.15",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
-                    }
-                },
-                "pify": {
-                    "version": "2.3.0",
-                    "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-                    "dev": true
-                },
-                "read-pkg": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                    "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-                    "dev": true,
-                    "requires": {
-                        "load-json-file": "1.1.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "1.1.0"
-                    }
-                },
-                "read-pkg-up": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                    "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-                    "dev": true,
-                    "requires": {
-                        "find-up": "1.1.2",
-                        "read-pkg": "1.1.0"
-                    }
-                },
-                "strip-bom": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                    "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-                    "dev": true,
-                    "requires": {
-                        "is-utf8": "0.2.1"
-                    }
                 }
             }
         },
@@ -13032,6 +12924,12 @@
             "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
             "dev": true
         },
+        "p-defer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+            "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+            "dev": true
+        },
         "p-each-series": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
@@ -13959,9 +13857,9 @@
             "dev": true
         },
         "react-dom": {
-            "version": "16.4.1",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.1.tgz",
-            "integrity": "sha512-1Gin+wghF/7gl4Cqcvr1DxFX2Osz7ugxSwl6gBqCMpdrxHjIFUS7GYxrFftZ9Ln44FHw0JxCFD9YtZsrbR5/4A==",
+            "version": "16.4.2",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.2.tgz",
+            "integrity": "sha512-Usl73nQqzvmJN+89r97zmeUpQDKDlh58eX6Hbs/ERdDHzeBzWy+ENk7fsGQ+5KxArV1iOFPT46/VneklK9zoWw==",
             "dev": true,
             "requires": {
                 "fbjs": "0.8.17",
@@ -14116,27 +14014,6 @@
             "dev": true,
             "requires": {
                 "resolve": "1.9.0"
-            }
-        },
-        "redent": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-            "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-            "dev": true,
-            "requires": {
-                "indent-string": "2.1.0",
-                "strip-indent": "1.0.1"
-            },
-            "dependencies": {
-                "strip-indent": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-                    "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-                    "dev": true,
-                    "requires": {
-                        "get-stdin": "4.0.1"
-                    }
-                }
             }
         },
         "regenerate": {
@@ -15140,13 +15017,13 @@
             }
         },
         "sockjs-client": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
-            "integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.3.0.tgz",
+            "integrity": "sha512-R9jxEzhnnrdxLCNln0xg5uGHqMnkhPSTzUZH2eXcR03S/On9Yvoq2wyUZILRUhZCNVu2PmwWVoyuiPz8th8zbg==",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "eventsource": "0.1.6",
+                "debug": "3.2.6",
+                "eventsource": "1.0.7",
                 "faye-websocket": "0.11.1",
                 "inherits": "2.0.3",
                 "json3": "3.3.2",
@@ -15154,12 +15031,12 @@
             },
             "dependencies": {
                 "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "2.0.0"
+                        "ms": "2.1.1"
                     }
                 },
                 "faye-websocket": {
@@ -15170,6 +15047,12 @@
                     "requires": {
                         "websocket-driver": "0.7.0"
                     }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
                 }
             }
         },
@@ -15264,52 +15147,73 @@
             "dev": true
         },
         "spdy": {
-            "version": "3.4.7",
-            "resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
-            "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.0.tgz",
+            "integrity": "sha512-ot0oEGT/PGUpzf/6uk4AWLqkq+irlqHXkrdbk51oWONh3bxQmBuljxPNl66zlRRcIJStWq0QkLUCPOPjgjvU0Q==",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "handle-thing": "1.2.5",
+                "debug": "4.1.1",
+                "handle-thing": "2.0.0",
                 "http-deceiver": "1.2.7",
-                "safe-buffer": "5.1.2",
                 "select-hose": "2.0.0",
-                "spdy-transport": "2.1.1"
+                "spdy-transport": "3.0.0"
             },
             "dependencies": {
                 "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
                     "dev": true,
                     "requires": {
-                        "ms": "2.0.0"
+                        "ms": "2.1.1"
                     }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
                 }
             }
         },
         "spdy-transport": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.1.tgz",
-            "integrity": "sha512-q7D8c148escoB3Z7ySCASadkegMmUZW8Wb/Q1u0/XBgDKMO880rLQDj8Twiew/tYi7ghemKUi/whSYOwE17f5Q==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
+            "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
+                "debug": "4.1.1",
                 "detect-node": "2.0.4",
                 "hpack.js": "2.1.6",
                 "obuf": "1.1.2",
-                "readable-stream": "2.3.6",
-                "safe-buffer": "5.1.2",
+                "readable-stream": "3.1.1",
                 "wbuf": "1.7.3"
             },
             "dependencies": {
                 "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
                     "dev": true,
                     "requires": {
-                        "ms": "2.0.0"
+                        "ms": "2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
+                    "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 }
             }
@@ -16346,12 +16250,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.1.tgz",
             "integrity": "sha512-X+eloHbgJGxczUk1WSjIvn7aC9oN3jVE3rQfRVKcgpavi3jxtCn0VVKtjOBj64Yop96UYn/ujJRpTbCdAF1vyg==",
-            "dev": true
-        },
-        "trim-newlines": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-            "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
             "dev": true
         },
         "trim-right": {
@@ -17950,62 +17848,53 @@
             }
         },
         "webpack-dev-middleware": {
-            "version": "3.1.2",
-            "resolved": "http://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.1.2.tgz",
-            "integrity": "sha512-Z11Zp3GTvCe6mGbbtma+lMB9xRfJcNtupXfmvFBujyXqLNms6onDnSi9f/Cb2rw6KkD5kgibOfxhN7npZwTiGA==",
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.4.0.tgz",
+            "integrity": "sha512-Q9Iyc0X9dP9bAsYskAVJ/hmIZZQwf/3Sy4xCAZgL5cUkjZmUZLt4l5HpbST/Pdgjn3u6pE7u5OdGd1apgzRujA==",
             "dev": true,
             "requires": {
-                "loud-rejection": "1.6.0",
                 "memory-fs": "0.4.1",
                 "mime": "2.4.0",
-                "path-is-absolute": "1.0.1",
                 "range-parser": "1.2.0",
-                "url-join": "4.0.0",
-                "webpack-log": "1.2.0"
-            },
-            "dependencies": {
-                "url-join": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.0.tgz",
-                    "integrity": "sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo=",
-                    "dev": true
-                }
+                "webpack-log": "2.0.0"
             }
         },
         "webpack-dev-server": {
-            "version": "3.1.3",
-            "resolved": "http://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.3.tgz",
-            "integrity": "sha512-UXfgQIPpdw2rByoUnCrMAIXCS7IJJMp5N0MDQNk9CuQvirCkuWlu7gQpCS8Kaiz4kogC4TdAQHG3jzh/DdqEWg==",
+            "version": "3.1.14",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.14.tgz",
+            "integrity": "sha512-mGXDgz5SlTxcF3hUpfC8hrQ11yhAttuUQWf1Wmb+6zo3x6rb7b9mIfuQvAPLdfDRCGRGvakBWHdHOa0I9p/EVQ==",
             "dev": true,
             "requires": {
                 "ansi-html": "0.0.7",
-                "array-includes": "3.0.3",
                 "bonjour": "3.5.0",
                 "chokidar": "2.0.4",
                 "compression": "1.7.3",
-                "connect-history-api-fallback": "1.5.0",
+                "connect-history-api-fallback": "1.6.0",
                 "debug": "3.1.0",
                 "del": "3.0.0",
                 "express": "4.16.4",
                 "html-entities": "1.2.1",
                 "http-proxy-middleware": "0.18.0",
-                "import-local": "1.0.0",
-                "internal-ip": "1.2.0",
+                "import-local": "2.0.0",
+                "internal-ip": "3.0.1",
                 "ip": "1.1.5",
                 "killable": "1.0.1",
                 "loglevel": "1.6.1",
                 "opn": "5.4.0",
                 "portfinder": "1.0.20",
+                "schema-utils": "1.0.0",
                 "selfsigned": "1.10.4",
+                "semver": "5.6.0",
                 "serve-index": "1.9.1",
                 "sockjs": "0.3.19",
-                "sockjs-client": "1.1.4",
-                "spdy": "3.4.7",
+                "sockjs-client": "1.3.0",
+                "spdy": "4.0.0",
                 "strip-ansi": "3.0.1",
                 "supports-color": "5.5.0",
-                "webpack-dev-middleware": "3.1.2",
-                "webpack-log": "1.2.0",
-                "yargs": "11.0.0"
+                "url": "0.11.0",
+                "webpack-dev-middleware": "3.4.0",
+                "webpack-log": "2.0.0",
+                "yargs": "12.0.2"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -18042,11 +17931,166 @@
                         }
                     }
                 },
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                    "dev": true,
+                    "requires": {
+                        "nice-try": "1.0.5",
+                        "path-key": "2.0.1",
+                        "semver": "5.6.0",
+                        "shebang-command": "1.2.0",
+                        "which": "1.3.1"
+                    }
+                },
+                "decamelize": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
+                    "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
+                    "dev": true,
+                    "requires": {
+                        "xregexp": "4.0.0"
+                    }
+                },
+                "execa": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+                    "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "6.0.5",
+                        "get-stream": "4.1.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
+                    }
+                },
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "3.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+                    "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+                    "dev": true,
+                    "requires": {
+                        "pump": "3.0.0"
+                    }
+                },
                 "has-flag": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
                     "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
                     "dev": true
+                },
+                "import-local": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+                    "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
+                    "dev": true,
+                    "requires": {
+                        "pkg-dir": "3.0.0",
+                        "resolve-cwd": "2.0.0"
+                    }
+                },
+                "invert-kv": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+                    "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+                    "dev": true
+                },
+                "lcid": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+                    "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+                    "dev": true,
+                    "requires": {
+                        "invert-kv": "2.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "3.0.0",
+                        "path-exists": "3.0.0"
+                    }
+                },
+                "mem": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/mem/-/mem-4.0.0.tgz",
+                    "integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
+                    "dev": true,
+                    "requires": {
+                        "map-age-cleaner": "0.1.3",
+                        "mimic-fn": "1.2.0",
+                        "p-is-promise": "1.1.0"
+                    }
+                },
+                "os-locale": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+                    "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+                    "dev": true,
+                    "requires": {
+                        "execa": "1.0.0",
+                        "lcid": "2.0.0",
+                        "mem": "4.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+                    "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "2.1.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+                    "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+                    "dev": true
+                },
+                "pkg-dir": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+                    "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "3.0.0"
+                    }
+                },
+                "pump": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+                    "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+                    "dev": true,
+                    "requires": {
+                        "end-of-stream": "1.4.1",
+                        "once": "1.4.0"
+                    }
                 },
                 "supports-color": {
                     "version": "5.5.0",
@@ -18058,29 +18102,29 @@
                     }
                 },
                 "yargs": {
-                    "version": "11.0.0",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
-                    "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
+                    "version": "12.0.2",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.2.tgz",
+                    "integrity": "sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==",
                     "dev": true,
                     "requires": {
                         "cliui": "4.1.0",
-                        "decamelize": "1.2.0",
-                        "find-up": "2.1.0",
+                        "decamelize": "2.0.0",
+                        "find-up": "3.0.0",
                         "get-caller-file": "1.0.3",
-                        "os-locale": "2.1.0",
+                        "os-locale": "3.1.0",
                         "require-directory": "2.1.1",
                         "require-main-filename": "1.0.1",
                         "set-blocking": "2.0.0",
                         "string-width": "2.1.1",
                         "which-module": "2.0.0",
                         "y18n": "3.2.1",
-                        "yargs-parser": "9.0.2"
+                        "yargs-parser": "10.1.0"
                     }
                 },
                 "yargs-parser": {
-                    "version": "9.0.2",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-                    "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+                    "version": "10.1.0",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+                    "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
                     "dev": true,
                     "requires": {
                         "camelcase": "4.1.0"
@@ -18089,61 +18133,13 @@
             }
         },
         "webpack-log": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-1.2.0.tgz",
-            "integrity": "sha512-U9AnICnu50HXtiqiDxuli5gLB5PGBo7VvcHx36jRZHwK4vzOYLbImqT4lwWwoMHdQWwEKw736fCHEekokTEKHA==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
+            "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "log-symbols": "2.2.0",
-                "loglevelnext": "1.0.5",
+                "ansi-colors": "3.2.3",
                 "uuid": "3.3.2"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "1.9.3"
-                    }
-                },
-                "chalk": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.5.0"
-                    }
-                },
-                "has-flag": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-                    "dev": true
-                },
-                "log-symbols": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-                    "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "2.4.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "3.0.0"
-                    }
-                }
             }
         },
         "webpack-sources": {
@@ -18377,6 +18373,12 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
             "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+            "dev": true
+        },
+        "xregexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
+            "integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg==",
             "dev": true
         },
         "xtend": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
         "query-string": "6.1.0",
         "react": "^16.4.1",
         "react-addons-test-utils": "15.6.2",
-        "react-dom": "16.4.1",
+        "react-dom": "^16.4.2",
         "react-editable-json-tree": "2.2.1",
         "react-jsonschema-form": "1.0.4",
         "react-test-renderer": "16.4.1",
@@ -83,7 +83,7 @@
         "webpack": "4.28.1",
         "webpack-bundle-analyzer": "^3.0.3",
         "webpack-cli": "2.0.12",
-        "webpack-dev-server": "3.1.3",
+        "webpack-dev-server": "^3.1.14",
         "webpack-visualizer-plugin": "0.1.11"
     },
     "engines": {


### PR DESCRIPTION
### CVE-2018-6341 react-dom
low severity
Vulnerable versions: >= 16.4.0, < 16.4.2
Patched version: 16.4.2
React applications which rendered to HTML using the ReactDOMServer API were not escaping user-supplied attribute names at render-time. That lack of escaping could lead to a cross-site scripting vulnerability. This vulnerability can only affect some server-rendered React apps. Purely client-rendered apps are not affected.

This issue affected minor releases 16.0.x, 16.1.x, 16.2.x, 16.3.x, and 16.4.x. It was fixed in 16.0.1, 16.1.2, 16.2.1, 16.3.3, and 16.4.2.

### CVE-2018-14732 webpack-dev-server
low severity
Vulnerable versions: < 3.1.11
Patched version: 3.1.11
An issue was discovered in lib/Server.js in webpack-dev-server before 3.1.11. Attackers are able to steal developer's code because the origin of requests is not checked by the WebSocket server, which is used for HMR (Hot Module Replacement). Anyone can receive the HMR message sent by the WebSocket server via a ws://127.0.0.1:8080/ connection from any origin.