### PR TITLE
fix: Add link with custom color in existing graph

### DIFF
--- a/src/components/graph/graph.helper.js
+++ b/src/components/graph/graph.helper.js
@@ -164,6 +164,7 @@ function _mapDataLinkToD3Link(link, index, d3Links = [], config, state = {}) {
         index,
         source,
         target,
+        color: link.color,
     };
 }
 
@@ -317,10 +318,11 @@ function initializeGraphState({ data, id, config }, state) {
 
     if (state && state.nodes) {
         graph = {
-            nodes: data.nodes.map(n =>
-                state.nodes[n.id]
-                    ? Object.assign({}, n, utils.pick(state.nodes[n.id], NODE_PROPS_WHITELIST))
-                    : Object.assign({}, n)
+            nodes: data.nodes.map(
+                n =>
+                    state.nodes[n.id]
+                        ? Object.assign({}, n, utils.pick(state.nodes[n.id], NODE_PROPS_WHITELIST))
+                        : Object.assign({}, n)
             ),
             links: data.links.map((l, index) => _mapDataLinkToD3Link(l, index, state && state.d3Links, config, state)),
         };


### PR DESCRIPTION
When a new link was added in real time by updating an existing graph instance, if it was configured to have a custom color with the `link.color` property, that value was ignored and the default color was applied instead. This issue was reported in #169.

The source of the problem was that, when generating a `d3Link` instance in the `_mapDataLinkToD3Link` method, the value of the `color` property was not kept. 

Only the `source` and `target` values were being added to the `d3Link` which would actually be rendered in the graph, and the `color` property was completely lost by the time the graph was to be drawn on the screen. The issue could be solved by adding a `color` property to the generated `d3Link` object.