### PR TITLE
Specify links in Graph component update

### DIFF
--- a/src/components/graph/graph.helper.js
+++ b/src/components/graph/graph.helper.js
@@ -144,8 +144,8 @@ function _mapDataLinkToD3Link(link, index, d3Links = [], config, state = {}) {
     if (d3Link) {
         const toggledDirected = state.config && state.config.directed && config.directed !== state.config.directed;
         const refinedD3Link = {
-            ...d3Link,
             index,
+            ...d3Link,
             ...customProps,
         };
 

--- a/src/components/graph/graph.helper.js
+++ b/src/components/graph/graph.helper.js
@@ -145,6 +145,7 @@ function _mapDataLinkToD3Link(link, index, d3Links = [], config, state = {}) {
         const toggledDirected = state.config && state.config.directed && config.directed !== state.config.directed;
         const refinedD3Link = {
             ...d3Link,
+            index,
             ...customProps,
         };
 

--- a/src/components/graph/graph.helper.js
+++ b/src/components/graph/graph.helper.js
@@ -137,7 +137,8 @@ function _initializeNodes(graphNodes) {
  * @memberof Graph/helper
  */
 function _mapDataLinkToD3Link(link, index, d3Links = [], config, state = {}) {
-    const d3Link = d3Links[index];
+    // find the matching link if it exists
+    const d3Link = d3Links.find(l => l.source.id === link.source && l.target.id === link.target);
     const customProps = utils.pick(link, LINK_CUSTOM_PROPS_WHITELIST);
 
     if (d3Link) {

--- a/test/graph/graph.helper.spec.js
+++ b/test/graph/graph.helper.spec.js
@@ -168,7 +168,7 @@ describe("Graph Helper", () => {
                         ]);
                         expect(newState.d3Links).toEqual([
                             {
-                                index: 0,
+                                index: 2,
                                 isHidden: false,
                                 source: {
                                     highlighted: false,

--- a/test/graph/graph.helper.spec.js
+++ b/test/graph/graph.helper.spec.js
@@ -94,6 +94,94 @@ describe("Graph Helper", () => {
                         },
                     ]);
                 });
+                describe("and the new state has nodes removed", () => {
+                    test("should create graph structure preserving subset of original structure", () => {
+                        const data = {
+                            nodes: [{ id: "B" }, { id: "C" }],
+                            links: [{ source: "B", target: "C" }],
+                        };
+                        const state = {
+                            nodes: {
+                                A: { x: 20, y: 40 },
+                                B: { x: 40, y: 60 },
+                                C: { x: 60, y: 80 },
+                            },
+                            links: [
+                                { source: "A", target: "B" },
+                                { source: "C", target: "A" },
+                                { source: "B", target: "C" },
+                            ],
+                            d3Links: [
+                                {
+                                    index: 0,
+                                    source: {
+                                        highlighted: false,
+                                        id: "A",
+                                    },
+                                    target: {
+                                        highlighted: false,
+                                        id: "B",
+                                    },
+                                },
+                                {
+                                    index: 1,
+                                    source: {
+                                        highlighted: false,
+                                        id: "C",
+                                    },
+                                    target: {
+                                        highlighted: false,
+                                        id: "A",
+                                    },
+                                },
+                                {
+                                    index: 2,
+                                    isHidden: false,
+                                    source: {
+                                        highlighted: false,
+                                        id: "B",
+                                    },
+                                    target: {
+                                        highlighted: false,
+                                        id: "C",
+                                    },
+                                },
+                            ],
+                            nodeIndexMapping: "nodeIndexMapping",
+                        };
+
+                        const newState = graphHelper.initializeGraphState({ data, id: "id", config: {} }, state);
+
+                        expect(newState.d3Nodes).toEqual([
+                            {
+                                highlighted: false,
+                                id: "B",
+                                x: 40,
+                                y: 60,
+                            },
+                            {
+                                highlighted: false,
+                                id: "C",
+                                x: 60,
+                                y: 80,
+                            },
+                        ]);
+                        expect(newState.d3Links).toEqual([
+                            {
+                                index: 2,
+                                isHidden: false,
+                                source: {
+                                    highlighted: false,
+                                    id: "B",
+                                },
+                                target: {
+                                    highlighted: false,
+                                    id: "C",
+                                },
+                            },
+                        ]);
+                    });
+                });
             });
 
             describe("and received state is empty", () => {

--- a/test/graph/graph.helper.spec.js
+++ b/test/graph/graph.helper.spec.js
@@ -168,7 +168,7 @@ describe("Graph Helper", () => {
                         ]);
                         expect(newState.d3Links).toEqual([
                             {
-                                index: 2,
+                                index: 0,
                                 isHidden: false,
                                 source: {
                                     highlighted: false,


### PR DESCRIPTION
I think this might fix #183. I was having the same problem when I was trying to update a graph by modifying the `data` prop in order to reduce the graph to a subset of the original. The right nodes would render but the links were sort of hit or miss. For me the issue was that `d3Links[index]` in `_mapDataLinkToD3Link` isn't necessarily going to be the same as `nextProps.data.links[index]`. Using the find function instead should make sure that they match. It's worked so far for my use cases. The change doesn't seem to break any tests, and I added one test that fails without the change but passes with it. I'm happy to add tests or make follow up changes if anyone is interested in merging this. 