### PR TITLE
Run CI on node 10.14.0 (additionally)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: node_js
+addons:
+    apt:
+        packages:
+            - libgconf-2-4
 node_js:
     - "8.9.0"
     - "10.14.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-    - "8.11.0"
+    - "8.9.0"
+    - "10.14.0"
 install:
     - npm install
 before_script:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1083,15 +1083,13 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
                     "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "is-glob": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "is-extglob": "^1.0.0"
                     }


### PR DESCRIPTION
- Run CI additionally against node [10.14.0 LTS](https://nodejs.org/uk/blog/release/v10.14.0/).
- Additionally, but most importantly, fixed issue in cypress CI integration mentioned here https://github.com/cypress-io/cypress/issues/4069