### PR TITLE
Feature/allow pass function in link.label property

### DIFF
--- a/cypress/integration/link.e2e.js
+++ b/cypress/integration/link.e2e.js
@@ -25,21 +25,11 @@ describe("[rd3g-link] link tests", function() {
     });
 
     describe("when some link.renderLabel is enable", function() {
-        beforeEach(function() {
-            cy.contains("link.renderLabel").scrollIntoView();
-            this.sandboxPO.getFieldInput("link.renderLabel").click();
-        });
-
-        describe("and some link has a 'label' property", function() {
+        describe("and some link has a 'labelProperty'", function() {
             it("should properly render the label in the link between two nodes", function() {
                 // link between nodes' 1 and 2 should have a label
-                this.link12PO.getLabel().contains("link 1 and 2");
+                this.link12PO.getLabel().contains("from 1 to 2");
             });
-        });
-
-        afterEach(function() {
-            cy.contains("link.renderLabel").scrollIntoView();
-            this.sandboxPO.getFieldInput("link.renderLabel").click();
         });
     });
 

--- a/cypress/integration/link.e2e.js
+++ b/cypress/integration/link.e2e.js
@@ -25,11 +25,21 @@ describe("[rd3g-link] link tests", function() {
     });
 
     describe("when some link.renderLabel is enable", function() {
+        beforeEach(function() {
+            cy.contains("link.renderLabel").scrollIntoView();
+            this.sandboxPO.getFieldInput("link.renderLabel").click();
+        });
+
         describe("and some link has a 'labelProperty'", function() {
             it("should properly render the label in the link between two nodes", function() {
                 // link between nodes' 1 and 2 should have a label
                 this.link12PO.getLabel().contains("from 1 to 2");
             });
+        });
+
+        afterEach(function() {
+            cy.contains("link.renderLabel").scrollIntoView();
+            this.sandboxPO.getFieldInput("link.renderLabel").click();
         });
     });
 

--- a/sandbox/data/small/small.config.js
+++ b/sandbox/data/small/small.config.js
@@ -33,9 +33,18 @@ module.exports = {
     },
     link: {
         color: "#d3d3d3",
+        fontColor: "red",
+        fontSize: 10,
+        highlightColor: "blue",
+        highlightFontWeight: "bold",
+        labelProperty: link => `from ${link.source} to ${link.target}`,
         opacity: 1,
+        renderLabel: true,
         semanticStrokeWidth: false,
         strokeWidth: 4,
-        highlightColor: "blue",
+    },
+    d3: {
+        gravity: -400,
+        linkLength: 300,
     },
 };

--- a/sandbox/data/small/small.config.js
+++ b/sandbox/data/small/small.config.js
@@ -39,7 +39,7 @@ module.exports = {
         highlightFontWeight: "bold",
         labelProperty: link => `from ${link.source} to ${link.target}`,
         opacity: 1,
-        renderLabel: true,
+        renderLabel: false,
         semanticStrokeWidth: false,
         strokeWidth: 4,
     },

--- a/src/components/graph/graph.builder.js
+++ b/src/components/graph/graph.builder.js
@@ -111,7 +111,12 @@ function buildLinkProps(link, nodes, links, config, linkCallbacks, highlightedNo
     let label = null;
 
     if (config.link.renderLabel) {
-        label = link[config.link.labelProperty];
+        if (typeof config.link.labelProperty === "function") {
+            label = config.link.labelProperty(link);
+        } else {
+            label = link[config.link.labelProperty];
+        }
+
         fontSize = link.fontSize || config.link.fontSize;
         fontColor = link.fontColor || config.link.fontColor;
         fontWeight = highlight ? config.link.highlightFontWeight : config.link.fontWeight;

--- a/src/components/graph/graph.config.js
+++ b/src/components/graph/graph.config.js
@@ -160,8 +160,9 @@
  * <img src="https://github.com/danielcaldas/react-d3-graph/blob/master/docs/rd3g-bend.gif?raw=true" width="820" height="480"/>
  * @param {number} [link.highlightFontSize=8] - fontSize in highlighted state.
  * @param {string} [link.highlightFontWeight="normal"] - fontWeight in highlighted state.
- * @param {boolean} [link.labelProperty="label"] - the property that will be rendered as label within some link. Note that
- * this property needs to be passed along the link payload (along side with source and target).
+ * @param {string|Function} [link.labelProperty="label"] - the property that will be rendered as label within some link. Note that
+ * this property needs to be passed along the link payload (along side with source and target). This property can also be a function
+ * that receives the link itself as argument and returns a custom string, similarly to what happens with `node.labelProperty`.
  * @param {string} [link.mouseCursor="pointer"] - {@link https://developer.mozilla.org/en/docs/Web/CSS/cursor?v=control|cursor}
  * property for when link is mouse hovered.
  * @param {number} [link.opacity=1] 🔍🔍🔍 - the default opacity value for links.

--- a/src/components/graph/graph.config.js
+++ b/src/components/graph/graph.config.js
@@ -252,6 +252,7 @@ export default {
         fontColor: "black",
         fontSize: 8,
         fontWeight: "normal",
+        // FIXME: highlightColor default should be "SAME", breaking change
         highlightColor: "#d3d3d3",
         highlightFontSize: 8,
         highlightFontWeight: "normal",


### PR DESCRIPTION
- Allow `link.labelProperty` to receive a custom function as well, similarly to `node.labelProperty`
- Fix docs for `link.labelProperty`