### PR TITLE
Fix: Update test with .toMatchSnapshot to test UI

### DIFF
--- a/test/graph/__snapshots__/graph.builder.spec.js.snap
+++ b/test/graph/__snapshots__/graph.builder.spec.js.snap
@@ -1,13 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Graph Helper #buildLinkProps when building props for a link and custom color is set to green should return green color in the props: green 1`] = `"green"`;
-
-exports[`Graph Helper #buildLinkProps when building props for a link and no custom color is set should return default color defined in link config: #d3d3d3 1`] = `"#d3d3d3"`;
-
-exports[`Graph Helper #buildNodeProps and custom strokeColor is set to yellow should return yellow strokeColor in the props: yellow 1`] = `"yellow"`;
-
-exports[`Graph Helper #buildNodeProps and no custom strokeColor is set should return the default strokeColor in the props: none 1`] = `"none"`;
-
 exports[`Graph Helper #buildNodeProps when node to build is the highlightedLink target (or source) and highlight degree is 0 should properly build node props () 1`] = `
 Object {
   "className": "node",

--- a/test/graph/__snapshots__/graph.builder.spec.js.snap
+++ b/test/graph/__snapshots__/graph.builder.spec.js.snap
@@ -1,0 +1,111 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Graph Helper #buildLinkProps when building props for a link and custom color is set to green should return green color in the props: green 1`] = `"green"`;
+
+exports[`Graph Helper #buildLinkProps when building props for a link and no custom color is set should return default color defined in link config: #d3d3d3 1`] = `"#d3d3d3"`;
+
+exports[`Graph Helper #buildNodeProps and custom strokeColor is set to yellow should return yellow strokeColor in the props: yellow 1`] = `"yellow"`;
+
+exports[`Graph Helper #buildNodeProps and no custom strokeColor is set should return the default strokeColor in the props: none 1`] = `"none"`;
+
+exports[`Graph Helper #buildNodeProps when node to build is the highlightedLink target (or source) and highlight degree is 0 should properly build node props () 1`] = `
+Object {
+  "className": "node",
+  "color": "green",
+  "cursor": "pointer",
+  "cx": 1,
+  "cy": 2,
+  "dx": 11.5,
+  "fill": "green",
+  "fontColor": "black",
+  "fontSize": 8,
+  "fontWeight": "normal",
+  "highlighted": false,
+  "id": "id",
+  "label": "id",
+  "onClickNode": undefined,
+  "onMouseOut": undefined,
+  "onMouseOverNode": undefined,
+  "onRightClickNode": undefined,
+  "opacity": undefined,
+  "overrideGlobalViewGenerator": undefined,
+  "renderLabel": true,
+  "size": 200,
+  "stroke": "none",
+  "strokeWidth": 1.5,
+  "svg": "file.svg",
+  "symbolType": undefined,
+  "type": "circle",
+  "viewGenerator": null,
+  "x": 1,
+  "y": 2,
+}
+`;
+
+exports[`Graph Helper #buildNodeProps when node to build is the highlightedLink target (or source) and highlight degree is bigger then 0 should properly build node props 1`] = `
+Object {
+  "className": "node",
+  "color": "green",
+  "cursor": "pointer",
+  "cx": 1,
+  "cy": 2,
+  "dx": 11.5,
+  "fill": "green",
+  "fontColor": "black",
+  "fontSize": 8,
+  "fontWeight": "normal",
+  "highlighted": false,
+  "id": "id",
+  "label": "id",
+  "onClickNode": undefined,
+  "onMouseOut": undefined,
+  "onMouseOverNode": undefined,
+  "onRightClickNode": undefined,
+  "opacity": undefined,
+  "overrideGlobalViewGenerator": undefined,
+  "renderLabel": true,
+  "size": 200,
+  "stroke": "none",
+  "strokeWidth": 1.5,
+  "svg": "file.svg",
+  "symbolType": undefined,
+  "type": "circle",
+  "viewGenerator": null,
+  "x": 1,
+  "y": 2,
+}
+`;
+
+exports[`Graph Helper #buildNodeProps when node to build is the highlightedNode should return node props with proper highlight values 1`] = `
+Object {
+  "className": "node",
+  "color": "green",
+  "cursor": "pointer",
+  "cx": 1,
+  "cy": 2,
+  "dx": 15.5,
+  "fill": "red",
+  "fontColor": "black",
+  "fontSize": 12,
+  "fontWeight": "bold",
+  "highlighted": true,
+  "id": "id",
+  "label": "id",
+  "onClickNode": undefined,
+  "onMouseOut": undefined,
+  "onMouseOverNode": undefined,
+  "onRightClickNode": undefined,
+  "opacity": 1,
+  "overrideGlobalViewGenerator": undefined,
+  "renderLabel": true,
+  "size": 200,
+  "stroke": "yellow",
+  "strokeWidth": 2,
+  "svg": "file.svg",
+  "symbolType": undefined,
+  "type": "circle",
+  "viewGenerator": null,
+  "x": 1,
+  "y": 2,
+}
+`;

--- a/test/graph/__snapshots__/graph.helper.spec.js.snap
+++ b/test/graph/__snapshots__/graph.helper.spec.js.snap
@@ -1,0 +1,297 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Graph Helper #initializeGraphState when valid graph data is provided and received state is empty should create new graph structure with nodes and links 1`] = `
+Object {
+  "0": Object {
+    "highlighted": false,
+    "id": "A",
+    "x": 0,
+    "y": 0,
+  },
+  "1": Object {
+    "highlighted": false,
+    "id": "B",
+    "x": 0,
+    "y": 0,
+  },
+  "2": Object {
+    "highlighted": false,
+    "id": "C",
+    "x": 0,
+    "y": 0,
+  },
+}
+`;
+
+exports[`Graph Helper #initializeGraphState when valid graph data is provided and received state is empty should create new graph structure with nodes and links 2`] = `
+Object {
+  "0": Object {
+    "source": "A",
+    "target": "B",
+  },
+  "1": Object {
+    "source": "C",
+    "target": "A",
+  },
+}
+`;
+
+exports[`Graph Helper #initializeGraphState when valid graph data is provided and received state was already initialized and the new state has nodes removed should create graph structure preserving subset of original structure 1`] = `
+Object {
+  "0": Object {
+    "highlighted": false,
+    "id": "B",
+    "x": 40,
+    "y": 60,
+  },
+  "1": Object {
+    "highlighted": false,
+    "id": "C",
+    "x": 60,
+    "y": 80,
+  },
+}
+`;
+
+exports[`Graph Helper #initializeGraphState when valid graph data is provided and received state was already initialized and the new state has nodes removed should create graph structure preserving subset of original structure 2`] = `
+Object {
+  "0": Object {
+    "index": 2,
+    "isHidden": false,
+    "source": Object {
+      "highlighted": false,
+      "id": "B",
+    },
+    "target": Object {
+      "highlighted": false,
+      "id": "C",
+    },
+  },
+}
+`;
+
+exports[`Graph Helper #initializeGraphState when valid graph data is provided and received state was already initialized should create graph structure absorbing stored nodes and links behavior 1`] = `
+Object {
+  "0": Object {
+    "highlighted": false,
+    "id": "A",
+    "x": 20,
+    "y": 40,
+  },
+  "1": Object {
+    "highlighted": false,
+    "id": "B",
+    "x": 40,
+    "y": 60,
+  },
+  "2": Object {
+    "highlighted": false,
+    "id": "C",
+    "x": 0,
+    "y": 0,
+  },
+}
+`;
+
+exports[`Graph Helper #initializeGraphState when valid graph data is provided and received state was already initialized should create graph structure absorbing stored nodes and links behavior 2`] = `
+Object {
+  "0": Object {
+    "index": 0,
+    "source": Object {
+      "highlighted": false,
+      "id": "A",
+    },
+    "target": Object {
+      "highlighted": false,
+      "id": "B",
+    },
+  },
+  "1": Object {
+    "index": 1,
+    "source": Object {
+      "highlighted": false,
+      "id": "C",
+    },
+    "target": Object {
+      "highlighted": false,
+      "id": "A",
+    },
+  },
+}
+`;
+
+exports[`Graph Helper #initializeGraphState when valid graph data is provided should return proper state object for given inputs 1`] = `
+Object {
+  "config": Object {
+    "config": "config",
+  },
+  "configUpdated": false,
+  "d3Links": Array [
+    Object {
+      "index": 0,
+      "source": Object {
+        "highlighted": false,
+        "id": "A",
+      },
+      "target": Object {
+        "highlighted": false,
+        "id": "B",
+      },
+    },
+    Object {
+      "index": 1,
+      "source": Object {
+        "highlighted": false,
+        "id": "C",
+      },
+      "target": Object {
+        "highlighted": false,
+        "id": "A",
+      },
+    },
+  ],
+  "d3Nodes": Array [
+    Object {
+      "highlighted": false,
+      "id": "A",
+      "x": 20,
+      "y": 40,
+    },
+    Object {
+      "highlighted": false,
+      "id": "B",
+      "x": 40,
+      "y": 60,
+    },
+    Object {
+      "highlighted": false,
+      "id": "C",
+      "x": 0,
+      "y": 0,
+    },
+  ],
+  "draggedNode": null,
+  "highlightedNode": "",
+  "id": "id",
+  "links": Object {
+    "A": Object {
+      "B": 1,
+      "C": 1,
+    },
+    "B": Object {
+      "A": 1,
+    },
+    "C": Object {
+      "A": 1,
+    },
+  },
+  "newGraphElements": false,
+  "nodes": Object {
+    "A": Object {
+      "highlighted": false,
+      "id": "A",
+      "x": 20,
+      "y": 40,
+    },
+    "B": Object {
+      "highlighted": false,
+      "id": "B",
+      "x": 40,
+      "y": 60,
+    },
+    "C": Object {
+      "highlighted": false,
+      "id": "C",
+      "x": 0,
+      "y": 0,
+    },
+  },
+  "simulation": Object {
+    "force": [MockFunction] {
+      "calls": Array [
+        Array [
+          "charge",
+          10,
+        ],
+        Array [
+          "x",
+          10,
+        ],
+        Array [
+          "y",
+          10,
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": Object {
+            "force": [MockFunction] {
+              "calls": Array [
+                Array [
+                  "charge",
+                  10,
+                ],
+                Array [
+                  "x",
+                  10,
+                ],
+                Array [
+                  "y",
+                  10,
+                ],
+              ],
+              "results": [Circular],
+            },
+          },
+        },
+        Object {
+          "type": "return",
+          "value": Object {
+            "force": [MockFunction] {
+              "calls": Array [
+                Array [
+                  "charge",
+                  10,
+                ],
+                Array [
+                  "x",
+                  10,
+                ],
+                Array [
+                  "y",
+                  10,
+                ],
+              ],
+              "results": [Circular],
+            },
+          },
+        },
+        Object {
+          "type": "return",
+          "value": Object {
+            "force": [MockFunction] {
+              "calls": Array [
+                Array [
+                  "charge",
+                  10,
+                ],
+                Array [
+                  "x",
+                  10,
+                ],
+                Array [
+                  "y",
+                  10,
+                ],
+              ],
+              "results": [Circular],
+            },
+          },
+        },
+      ],
+    },
+  },
+  "transform": 1,
+}
+`;

--- a/test/graph/graph.builder.spec.js
+++ b/test/graph/graph.builder.spec.js
@@ -47,7 +47,7 @@ describe("Graph Helper", () => {
                         1
                     );
 
-                    expect(props.stroke).toMatchSnapshot(that.config.link.color);
+                    expect(props.stroke).toEqual(that.config.link.color);
                 });
             });
 
@@ -64,7 +64,7 @@ describe("Graph Helper", () => {
                         1
                     );
 
-                    expect(props.stroke).toMatchSnapshot("green");
+                    expect(props.stroke).toEqual("green");
                 });
             });
         });
@@ -101,33 +101,7 @@ describe("Graph Helper", () => {
                 });
                 const props = graphHelper.buildNodeProps(that.node, that.config, undefined, "id", undefined, 1);
 
-                expect(props).toMatchSnapshot({
-                    ...that.node,
-                    className: "node",
-                    cursor: "pointer",
-                    cx: 1,
-                    cy: 2,
-                    dx: 15.5,
-                    fill: "red",
-                    fontSize: 12,
-                    fontWeight: "bold",
-                    fontColor: "black",
-                    id: "id",
-                    label: "id",
-                    onClickNode: undefined,
-                    onRightClickNode: undefined,
-                    onMouseOut: undefined,
-                    onMouseOverNode: undefined,
-                    opacity: 1,
-                    renderLabel: true,
-                    size: 200,
-                    stroke: "yellow",
-                    strokeWidth: 2,
-                    svg: "file.svg",
-                    type: "circle",
-                    viewGenerator: null,
-                    overrideGlobalViewGenerator: undefined,
-                });
+                expect(props).toMatchSnapshot();
             });
         });
         describe("when node to build is the highlightedLink target (or source)", () => {
@@ -147,33 +121,7 @@ describe("Graph Helper", () => {
                         1
                     );
 
-                    expect(props).toMatchSnapshot({
-                        ...that.node,
-                        className: "node",
-                        cursor: "pointer",
-                        cx: 1,
-                        cy: 2,
-                        dx: 11.5,
-                        fill: "green",
-                        fontSize: 8,
-                        fontWeight: "normal",
-                        fontColor: "black",
-                        id: "id",
-                        label: "id",
-                        onClickNode: undefined,
-                        onRightClickNode: undefined,
-                        onMouseOut: undefined,
-                        onMouseOverNode: undefined,
-                        opacity: undefined,
-                        renderLabel: true,
-                        size: 200,
-                        stroke: "none",
-                        strokeWidth: 1.5,
-                        svg: "file.svg",
-                        type: "circle",
-                        viewGenerator: null,
-                        overrideGlobalViewGenerator: undefined,
-                    });
+                    expect(props).toMatchSnapshot();
                 });
             });
             describe("and highlight degree is bigger then 0", () => {
@@ -192,33 +140,7 @@ describe("Graph Helper", () => {
                         1
                     );
 
-                    expect(props).toMatchSnapshot({
-                        ...that.node,
-                        className: "node",
-                        cursor: "pointer",
-                        cx: 1,
-                        cy: 2,
-                        dx: 11.5,
-                        fill: "green",
-                        fontSize: 8,
-                        fontWeight: "normal",
-                        fontColor: "black",
-                        id: "id",
-                        label: "id",
-                        onClickNode: undefined,
-                        onRightClickNode: undefined,
-                        onMouseOut: undefined,
-                        onMouseOverNode: undefined,
-                        opacity: undefined,
-                        renderLabel: true,
-                        size: 200,
-                        stroke: "none",
-                        strokeWidth: 1.5,
-                        svg: "file.svg",
-                        type: "circle",
-                        viewGenerator: null,
-                        overrideGlobalViewGenerator: undefined,
-                    });
+                    expect(props).toMatchSnapshot();
                 });
             });
         });
@@ -226,7 +148,7 @@ describe("Graph Helper", () => {
             test("should return the default strokeColor in the props", () => {
                 const props = graphHelper.buildNodeProps(that.node, that.config, undefined, undefined, undefined, 1);
 
-                expect(props.stroke).toMatchSnapshot("none");
+                expect(props.stroke).toEqual("none");
             });
         });
         describe("and custom strokeColor is set to yellow", () => {
@@ -240,7 +162,7 @@ describe("Graph Helper", () => {
                     1
                 );
 
-                expect(props.stroke).toMatchSnapshot("yellow");
+                expect(props.stroke).toEqual("yellow");
             });
         });
     });

--- a/test/graph/graph.builder.spec.js
+++ b/test/graph/graph.builder.spec.js
@@ -47,7 +47,7 @@ describe("Graph Helper", () => {
                         1
                     );
 
-                    expect(props.stroke).toEqual(that.config.link.color);
+                    expect(props.stroke).toMatchSnapshot(that.config.link.color);
                 });
             });
 
@@ -64,7 +64,7 @@ describe("Graph Helper", () => {
                         1
                     );
 
-                    expect(props.stroke).toEqual("green");
+                    expect(props.stroke).toMatchSnapshot("green");
                 });
             });
         });
@@ -101,7 +101,7 @@ describe("Graph Helper", () => {
                 });
                 const props = graphHelper.buildNodeProps(that.node, that.config, undefined, "id", undefined, 1);
 
-                expect(props).toEqual({
+                expect(props).toMatchSnapshot({
                     ...that.node,
                     className: "node",
                     cursor: "pointer",
@@ -147,7 +147,7 @@ describe("Graph Helper", () => {
                         1
                     );
 
-                    expect(props).toEqual({
+                    expect(props).toMatchSnapshot({
                         ...that.node,
                         className: "node",
                         cursor: "pointer",
@@ -192,7 +192,7 @@ describe("Graph Helper", () => {
                         1
                     );
 
-                    expect(props).toEqual({
+                    expect(props).toMatchSnapshot({
                         ...that.node,
                         className: "node",
                         cursor: "pointer",
@@ -226,7 +226,7 @@ describe("Graph Helper", () => {
             test("should return the default strokeColor in the props", () => {
                 const props = graphHelper.buildNodeProps(that.node, that.config, undefined, undefined, undefined, 1);
 
-                expect(props.stroke).toEqual("none");
+                expect(props.stroke).toMatchSnapshot("none");
             });
         });
         describe("and custom strokeColor is set to yellow", () => {
@@ -240,7 +240,7 @@ describe("Graph Helper", () => {
                     1
                 );
 
-                expect(props.stroke).toEqual("yellow");
+                expect(props.stroke).toMatchSnapshot("yellow");
             });
         });
     });

--- a/test/graph/graph.helper.spec.js
+++ b/test/graph/graph.helper.spec.js
@@ -49,7 +49,7 @@ describe("Graph Helper", () => {
 
                     const newState = graphHelper.initializeGraphState({ data, id: "id", config: {} }, state);
 
-                    expect(newState.d3Nodes).toEqual([
+                    expect(newState.d3Nodes).toMatchSnapshot([
                         {
                             highlighted: false,
                             id: "A",
@@ -69,7 +69,7 @@ describe("Graph Helper", () => {
                             y: 0,
                         },
                     ]);
-                    expect(newState.d3Links).toEqual([
+                    expect(newState.d3Links).toMatchSnapshot([
                         {
                             index: 0,
                             source: {
@@ -152,7 +152,7 @@ describe("Graph Helper", () => {
 
                         const newState = graphHelper.initializeGraphState({ data, id: "id", config: {} }, state);
 
-                        expect(newState.d3Nodes).toEqual([
+                        expect(newState.d3Nodes).toMatchSnapshot([
                             {
                                 highlighted: false,
                                 id: "B",
@@ -166,7 +166,7 @@ describe("Graph Helper", () => {
                                 y: 80,
                             },
                         ]);
-                        expect(newState.d3Links).toEqual([
+                        expect(newState.d3Links).toMatchSnapshot([
                             {
                                 index: 2,
                                 isHidden: false,
@@ -194,7 +194,7 @@ describe("Graph Helper", () => {
 
                     const newState = graphHelper.initializeGraphState({ data, id: "id", config: {} }, state);
 
-                    expect(newState.d3Nodes).toEqual([
+                    expect(newState.d3Nodes).toMatchSnapshot([
                         {
                             highlighted: false,
                             id: "A",
@@ -214,7 +214,7 @@ describe("Graph Helper", () => {
                             y: 0,
                         },
                     ]);
-                    expect(newState.d3Links).toEqual([
+                    expect(newState.d3Links).toMatchSnapshot([
                         {
                             source: "A",
                             target: "B",
@@ -257,7 +257,7 @@ describe("Graph Helper", () => {
 
                 const newState = graphHelper.initializeGraphState({ data, id: "id", config: undefined }, state);
 
-                expect(newState).toEqual({
+                expect(newState).toMatchSnapshot({
                     config: {
                         config: "config",
                     },


### PR DESCRIPTION
This PR is for issue #236 . 
Replaced the `.toEqual` with the `.toMatchSnapshot` to test the UI.