### PR TITLE
Custom Node Sandbox Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-d3-graph",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "React component to build interactive and configurable graphs with d3 effortlessly",
   "author": "Daniel Caldas",
   "license": "MIT",

--- a/sandbox/data/custom-node/custom-node.config.js
+++ b/sandbox/data/custom-node/custom-node.config.js
@@ -1,7 +1,7 @@
 import React from "react";
 import CustomNode from "./CustomNode";
 
-module.exports = {
+export default {
     automaticRearrangeAfterDropNode: false,
     collapsible: false,
     height: 400,


### PR DESCRIPTION
Webpack now recognizes exported the `custom-node.config.js` file correctly. The issue was having an `import` and `module.exports` statement in the same file. See other example [here](https://stackoverflow.com/questions/42449999/webpack-import-module-exports-in-the-same-module-caused-error). Attempt to solve Issue #252 
