### PR TITLE
Pass the event of onClickGraph to the prop

### DIFF
--- a/src/components/graph/Graph.jsx
+++ b/src/components/graph/Graph.jsx
@@ -313,7 +313,7 @@ export default class Graph extends React.Component {
         const svgContainerName = `svg-container-${this.state.id}`;
 
         if (tagName.toUpperCase() === "SVG" && name === svgContainerName) {
-            this.props.onClickGraph && this.props.onClickGraph();
+            this.props.onClickGraph && this.props.onClickGraph(e);
         }
     };
 


### PR DESCRIPTION
This is vital for getting the coordinates of the click. Unless you know of another way?