### PR TITLE
Update docs for automaticRearrangeAfterDropNode prop

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -908,10 +908,12 @@ have a higher level of granularity. These properties can be defined in the graph
           <div>
             <span class='code bold'>automaticRearrangeAfterDropNode</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>
             = <code>false</code>)</code>
-	    🚅🚅🚅 when true performing a node drag and drop should automatically
-rearrange all nodes positions based on new position of dragged node (note:
-<strong>staticGraph</strong>
- should be false).
+            🚅🚅🚅 when true performing a node drag and drop should automatically
+            rearrange all nodes positions based on new position of dragged node (note: <b>staticGraph</b> should be false). A few notes on this property:
+            <ul>
+            <li><b>automaticRearrangeAfterDropNode</b> needs to be set before the first graph render. Only the first set value will take effect.</li>
+            <li><b>automaticRearrangeAfterDropNode</b> won't work together with <b>nodeHighlightBehavior</b> (currently a known limitation, to be address in the future <a href="https://github.com/danielcaldas/react-d3-graph/issues/261" target="_blank">GitHub #261</a>).</li>
+            </ul>
 
           </div>
 

--- a/src/components/graph/graph.config.js
+++ b/src/components/graph/graph.config.js
@@ -37,10 +37,14 @@
  *
  * <h2 id="config-global"><a href="#config-global">#</a>  Graph global configurations</h2>
  * @param {boolean} [automaticRearrangeAfterDropNode=false] - 🚅🚅🚅 when true performing a node drag and drop should automatically
- * rearrange all nodes positions based on new position of dragged node (note: <b>staticGraph</b> should be false).
+ * rearrange all nodes positions based on new position of dragged node (note: <b>staticGraph</b> should be false). A few notes on this property:
+ * <ul>
+ * <li><b>automaticRearrangeAfterDropNode</b> needs to be set before the first graph render. Only the first set value will take effect.</li>
+ * <li><b>automaticRearrangeAfterDropNode</b> won't work together with <b>nodeHighlightBehavior</b> (currently a known limitation, to be address in the future <a href="https://github.com/danielcaldas/react-d3-graph/issues/261" target="_blank">GitHub issue #261</a>).</li>
+ * </ul>
  * @param {boolean} [collapsible=false] - 🚅🚅🚅 Allow leaf neighbors nodes to be collapsed (folded), this will allow users to clear the way out and focus on the parts of the graph that really matter.
  * To see an example of this behavior you can access this sandbox link that has a specific set up to experiment this feature. <b>NOTE</b>: At this moment
- * nodes without connections (orphan nodes) are not rendered when this property is activated (see <a target="_blank" href="https://github.com/danielcaldas/react-d3-graph/issues/129">react-d3-graph/issues/#129</a>).
+ * nodes without connections (orphan nodes) are not rendered when this property is activated (see <a target="_blank" href="https://github.com/danielcaldas/react-d3-graph/issues/129">GitHub issue #129</a>).
  * </br>
  * <img src="https://github.com/danielcaldas/react-d3-graph/blob/master/docs/rd3g-collapsible.gif?raw=true" width="820" height="480"/>
  * @param {boolean} [directed=false] - This property makes react-d3-graph handle your graph as a directed graph. It will


### PR DESCRIPTION
This PR addresses the problems pointed for the property [automaticRearrangeAfterDropNode](https://goodguydaniel.com/react-d3-graph/docs/index.html) in https://github.com/danielcaldas/react-d3-graph/issues/261. Thanks @felipeboffnunes for reporting