### PR TITLE
node_label changes enabled local param for renderLabel

### DIFF
--- a/src/components/graph/graph.builder.js
+++ b/src/components/graph/graph.builder.js
@@ -206,7 +206,7 @@ function buildNodeProps(node, config, nodeCallbacks = {}, highlightedNode, highl
         label,
         opacity,
         overrideGlobalViewGenerator: !node.viewGenerator && node.svg,
-        renderLabel: config.node.renderLabel,
+        renderLabel: node.renderLabel || config.node.renderLabel,
         size: nodeSize * t,
         stroke,
         strokeWidth: strokeWidth * t,


### PR DESCRIPTION
https://github.com/danielcaldas/react-d3-graph/issues/192  i added renderlabel it took so much time because i am not able to reproduce the problem in my local however i understand the problem of OP this i have made this changes.

Also regarding my earlier changes in this repo when i install the library i dont see the change  i am still not able to change localLink but it works fine on the hosted example but not on my project 
regards
Atharva
