### PR TITLE
Reorganizing the computation of arrows and links for circle nodes

### DIFF
--- a/src/components/graph/graph.builder.js
+++ b/src/components/graph/graph.builder.js
@@ -7,6 +7,7 @@ import CONST from "./graph.const";
 
 import { buildLinkPathDefinition } from "../link/link.helper";
 import { getMarkerId } from "../marker/marker.helper";
+import { getNormalizedNodeCoordinates } from "./graph.helper";
 
 /**
  * Get the correct node opacity in order to properly make decisions based on context such as currently highlighted node.
@@ -53,12 +54,16 @@ function _getNodeOpacity(node, highlightedNode, highlightedLink, config) {
  */
 function buildLinkProps(link, nodes, links, config, linkCallbacks, highlightedNode, highlightedLink, transform) {
     const { source, target } = link;
-    const x1 = nodes?.[source]?.x || 0;
-    const y1 = nodes?.[source]?.y || 0;
-    const x2 = nodes?.[target]?.x || 0;
-    const y2 = nodes?.[target]?.y || 0;
+
+    let x1 = nodes?.[source]?.x || 0;
+
+    let y1 = nodes?.[source]?.y || 0;
+
+    let x2 = nodes?.[target]?.x || 0;
+
+    let y2 = nodes?.[target]?.y || 0;
+
     const type = link.type || config.link.type;
-    const d = buildLinkPathDefinition({ source: { x: x1, y: y1 }, target: { x: x2, y: y2 } }, type);
 
     let mainNodeParticipates = false;
 
@@ -120,6 +125,14 @@ function buildLinkProps(link, nodes, links, config, linkCallbacks, highlightedNo
         fontColor = link.fontColor || config.link.fontColor;
         fontWeight = highlight ? config.link.highlightFontWeight : config.link.fontWeight;
     }
+
+    const normalizedNodeCoordinates = getNormalizedNodeCoordinates(
+        { source: { x: x1, y: y1 }, target: { x: x2, y: y2 } },
+        nodes,
+        config,
+        strokeWidth
+    );
+    const d = buildLinkPathDefinition(normalizedNodeCoordinates, type);
 
     return {
         className: CONST.LINK_CLASS_NAME,

--- a/src/components/graph/graph.helper.js
+++ b/src/components/graph/graph.helper.js
@@ -482,7 +482,7 @@ function getNormalizedNodeCoordinates({ source = {}, target = {} }, nodes, confi
 
     let { x: x2, y: y2 } = target;
 
-    if (config.node) {
+    if (config.node && !config.node.viewGenerator) {
         // Arrow configuration is only available for circles for now
         switch (config.node.symbolType) {
             case CONST.SYMBOLS.CIRCLE: {

--- a/src/components/graph/graph.renderer.jsx
+++ b/src/components/graph/graph.renderer.jsx
@@ -6,7 +6,7 @@
 import React from "react";
 
 import CONST from "./graph.const";
-import { MARKERS, MARKER_SMALL_SIZE, MARKER_MEDIUM_OFFSET, MARKER_LARGE_OFFSET } from "../marker/marker.const";
+import { MARKERS } from "../marker/marker.const";
 
 import Link from "../link/Link";
 import Node from "../node/Node";
@@ -14,6 +14,7 @@ import Marker from "../marker/Marker";
 import { buildLinkProps, buildNodeProps } from "./graph.builder";
 import { getId } from "../graph/graph.helper";
 import { isNodeVisible } from "./collapse.helper";
+import { getMarkerSize } from "../marker/marker.helper";
 
 /**
  * Build Link components given a list of links.
@@ -105,10 +106,7 @@ function _renderDefs() {
             return cachedDefs;
         }
 
-        const small = MARKER_SMALL_SIZE;
-        const medium = small + (MARKER_MEDIUM_OFFSET * config.maxZoom) / 3;
-        const large = small + (MARKER_LARGE_OFFSET * config.maxZoom) / 3;
-
+        const { small, medium, large } = getMarkerSize(config);
         const markerProps = {
             markerWidth: config.link.markerWidth,
             markerHeight: config.link.markerHeight,

--- a/src/components/marker/marker.helper.js
+++ b/src/components/marker/marker.helper.js
@@ -3,7 +3,15 @@
  * @description
  * Offers a series of methods to compute proper markers within a given context.
  */
-import { MARKERS, SIZES, HIGHLIGHTED } from "./marker.const";
+import {
+    MARKERS,
+    SIZES,
+    HIGHLIGHTED,
+    MARKER_SMALL_SIZE,
+    MARKER_MEDIUM_OFFSET,
+    MARKER_LARGE_OFFSET,
+} from "./marker.const";
+import CONST from "../graph/graph.const";
 
 /**
  * This function is a key template builder to access MARKERS structure.
@@ -93,4 +101,31 @@ function _memoizedComputeMarkerId() {
  */
 const getMarkerId = _memoizedComputeMarkerId();
 
-export { getMarkerId };
+/**
+ * Computes the three marker sizes
+ *
+ * For supported shapes in {@link Graph/helper/getNormalizedNodeCoordinates}, the function should return 0,
+ * to be able to control more accurately nodes and arrows sizes and positions in directional graphs.
+ *
+ * @param {Object} config - the graph config object.
+ * @returns {Object} size of markers
+ */
+function getMarkerSize(config) {
+    let small = MARKER_SMALL_SIZE;
+
+    let medium = small + (MARKER_MEDIUM_OFFSET * config.maxZoom) / 3;
+
+    let large = small + (MARKER_LARGE_OFFSET * config.maxZoom) / 3;
+
+    switch (config.node.symbolType) {
+        case CONST.SYMBOLS.CIRCLE:
+            small = 0;
+            medium = 0;
+            large = 0;
+            break;
+    }
+
+    return { small: small, medium: medium, large: large };
+}
+
+export { getMarkerId, getMarkerSize };

--- a/src/components/marker/marker.helper.js
+++ b/src/components/marker/marker.helper.js
@@ -117,12 +117,14 @@ function getMarkerSize(config) {
 
     let large = small + (MARKER_LARGE_OFFSET * config.maxZoom) / 3;
 
-    switch (config.node.symbolType) {
-        case CONST.SYMBOLS.CIRCLE:
-            small = 0;
-            medium = 0;
-            large = 0;
-            break;
+    if (config.node && !config.node.viewGenerator) {
+        switch (config.node.symbolType) {
+            case CONST.SYMBOLS.CIRCLE:
+                small = 0;
+                medium = 0;
+                large = 0;
+                break;
+        }
     }
 
     return { small: small, medium: medium, large: large };

--- a/test/graph/__snapshots__/graph.snapshot.spec.js.snap
+++ b/test/graph/__snapshots__/graph.snapshot.spec.js.snap
@@ -22,7 +22,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
         markerHeight={6}
         markerWidth={6}
         orient="auto"
-        refX={16}
+        refX={0}
         refY="0"
         viewBox="0 -5 10 10"
       >
@@ -37,7 +37,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
         markerHeight={6}
         markerWidth={6}
         orient="auto"
-        refX={16}
+        refX={0}
         refY="0"
         viewBox="0 -5 10 10"
       >
@@ -52,7 +52,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
         markerHeight={6}
         markerWidth={6}
         orient="auto"
-        refX={21.333333333333332}
+        refX={0}
         refY="0"
         viewBox="0 -5 10 10"
       >
@@ -67,7 +67,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
         markerHeight={6}
         markerWidth={6}
         orient="auto"
-        refX={21.333333333333332}
+        refX={0}
         refY="0"
         viewBox="0 -5 10 10"
       >
@@ -82,7 +82,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
         markerHeight={6}
         markerWidth={6}
         orient="auto"
-        refX={26.666666666666664}
+        refX={0}
         refY="0"
         viewBox="0 -5 10 10"
       >
@@ -97,7 +97,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
         markerHeight={6}
         markerWidth={6}
         orient="auto"
-        refX={26.666666666666664}
+        refX={0}
         refY="0"
         viewBox="0 -5 10 10"
       >
@@ -118,7 +118,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M40,200A0,0 0 0,1 140,20"
+          d="M402.6029494893985485,200-4.685309080917388A0,0 0 0,1 137.39705051060145,24.68530908091739"
           id="Harry,Sally"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -138,7 +138,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M40,200A0,0 0 0,1 20,110"
+          d="M40-1.1627040942275513,200-5.232168424023981A0,0 0 0,1 21.16270409422755,115.23216842402398"
           id="Harry,Mario"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -158,7 +158,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M30,184A0,0 0 0,1 305,745"
+          d="M302.3591551111937417,1844.812676426835234A0,0 0 0,1 302.64084488880627,740.1873235731648"
           id="Sarah,Alice"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -178,7 +178,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M200,300A0,0 0 0,1 305,745"
+          d="M2001.230871970649426,3005.2165526375142335A0,0 0 0,1 303.76912802935055,739.7834473624857"
           id="Eveie,Alice"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -198,7 +198,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M120,270A0,0 0 0,1 305,745"
+          d="M1201.9451766013189067,2704.994372354737734A0,0 0 0,1 303.0548233986811,740.0056276452623"
           id="Peter,Alice"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -218,7 +218,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M20,110A0,0 0 0,1 305,745"
+          d="M202.194669099098748,1104.889876764658614A0,0 0 0,1 302.80533090090125,740.1101232353413"
           id="Mario,Alice"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -238,7 +238,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M190,609A0,0 0 0,1 305,745"
+          d="M1903.4607726849715568,6094.092739870922885A0,0 0 0,1 301.5392273150284,740.9072601290771"
           id="James,Alice"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -258,7 +258,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M40,200A0,0 0 0,1 101,201"
+          d="M405.359080979074426,2000.0878537865422037A0,0 0 0,1 95.64091902092558,200.9121462134578"
           id="Harry,Carol"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -278,7 +278,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M40,200A0,0 0 0,1 2,200"
+          d="M40-5.359801043703684,2000A0,0 0 0,1 7.359801043703684,200"
           id="Harry,Nicky"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -298,7 +298,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M404,404A0,0 0 0,1 14,30"
+          d="M404-3.868474145942595,404-3.709767514314181A0,0 0 0,1 17.868474145942596,33.70976751431418"
           id="Bobby,Frank"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -318,7 +318,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M305,745A0,0 0 0,1 20,110"
+          d="M305-2.194669099098748,745-4.889876764658614A0,0 0 0,1 22.194669099098746,114.88987676465861"
           id="Alice,Mario"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -338,7 +338,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M40,200A0,0 0 0,1 14,250"
+          d="M40-2.472758879369286,2004.755305537248627A0,0 0 0,1 16.472758879369287,245.24469446275137"
           id="Harry,Lynne"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -358,7 +358,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M30,184A0,0 0 0,1 190,609"
+          d="M301.8884174089776617,1845.016108742596914A0,0 0 0,1 188.11158259102234,603.9838912574031"
           id="Sarah,James"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -378,7 +378,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M14,259A0,0 0 0,1 190,609"
+          d="M142.4079147156322325,2594.788466764041372A0,0 0 0,1 187.59208528436776,604.2115332359587"
           id="Roger,James"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -398,7 +398,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M409,500A0,0 0 0,1 190,609"
+          d="M409-4.798325813522697,5002.388207824995315A0,0 0 0,1 194.7983258135227,606.6117921750047"
           id="Maddy,James"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -418,7 +418,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M520,123A0,0 0 0,1 14,259"
+          d="M520-5.1761004847648815,1231.3912048733755413A0,0 0 0,1 19.17610048476488,257.60879512662444"
           id="Sonny,Roger"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -438,7 +438,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M190,609A0,0 0 0,1 14,259"
+          d="M190-2.4079147156322325,609-4.788466764041372A0,0 0 0,1 16.40791471563223,263.78846676404135"
           id="James,Roger"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -458,7 +458,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M305,745A0,0 0 0,1 120,270"
+          d="M305-1.9451766013189067,745-4.994372354737734A0,0 0 0,1 121.9451766013189,274.9943723547377"
           id="Alice,Peter"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -478,7 +478,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M14,20A0,0 0 0,1 120,270"
+          d="M142.0922556386763027,204.934565185557317A0,0 0 0,1 117.9077443613237,265.0654348144427"
           id="Johan,Peter"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -498,7 +498,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M305,745A0,0 0 0,1 200,300"
+          d="M305-1.230871970649426,745-5.2165526375142335A0,0 0 0,1 201.23087197064942,305.2165526375142"
           id="Alice,Eveie"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -518,7 +518,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M40,200A0,0 0 0,1 200,300"
+          d="M404.545102194865424,2002.8406888717908902A0,0 0 0,1 195.45489780513458,297.1593111282091"
           id="Harry,Eveie"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -538,7 +538,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M200,300A0,0 0 0,1 40,200"
+          d="M200-4.545102194865424,300-2.8406888717908902A0,0 0 0,1 44.54510219486542,202.8406888717909"
           id="Eveie,Harry"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -558,7 +558,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M20,1A0,0 0 0,1 90,90"
+          d="M203.3134907219103313,14.212866775000279A0,0 0 0,1 86.68650927808967,85.78713322499972"
           id="Henry,Mikey"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -578,7 +578,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M90,656A0,0 0 0,1 90,90"
+          d="M900,656-5.359801043703684A0,0 0 0,1 90,95.35980104370368"
           id="Elric,Mikey"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -598,7 +598,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M190,609A0,0 0 0,1 30,184"
+          d="M190-1.8884174089776617,609-5.016108742596914A0,0 0 0,1 31.888417408977663,189.0161087425969"
           id="James,Sarah"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -618,7 +618,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M305,745A0,0 0 0,1 30,184"
+          d="M305-2.3591551111937417,745-4.812676426835234A0,0 0 0,1 32.35915511119374,188.81267642683522"
           id="Alice,Sarah"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -638,7 +638,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M190,609A0,0 0 0,1 409,500"
+          d="M1904.798325813522697,609-2.388207824995315A0,0 0 0,1 404.2016741864773,502.38820782499533"
           id="James,Maddy"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -658,7 +658,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M120,270A0,0 0 0,1 14,20"
+          d="M120-2.0922556386763027,270-4.934565185557317A0,0 0 0,1 16.092255638676303,24.934565185557318"
           id="Peter,Johan"
           onClick={[Function]}
           onContextMenu={[Function]}


### PR DESCRIPTION
As explained in #265, I think that it would be better to make arrows points to nodes and not to the middle (under) the nodes. 

This PR solves this arrow problem when config is *circle*

**Some tests fail, as it changes from snapshots**. I will change the snapshots if the PR is accepted

![screen-pr](https://user-images.githubusercontent.com/26838971/69479855-54951000-0e02-11ea-862e-7b1310b53c2a.png)
![screen-pr2](https://user-images.githubusercontent.com/26838971/69479856-54951000-0e02-11ea-9852-222d7d73c4e4.png)

