### PR TITLE
Adding a parameter in config to be able to disable link force

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -362,6 +362,7 @@ const graph = {
         -   If value is negative, nodes will repel each other. Most of the times this is what we want, so nodes don"t overlap. (optional, default `-100`)
     -   `d3.linkLength` **[number][96]** the length of each link from the center of the nodes it joins. (optional, default `100`)
     -   `d3.linkStrength` **[number][96]** [see d3-force link.strength][107]
+    -   `d3.disableLinkForce` **[number][96]** when setting this value to true, the nodes will stay at the position chosen by the user, and no other d3 simulation will be done. (optional, default `false`)
         <br/> (optional, default `1`)
 -   `node` **[Object][99]** node object is explained in next section. ⬇️<h2 id="config-node"><a href="#config-node">#</a> Node level configurations</h2>
     -   `node.color` **[string][98]** 🔍🔍🔍 this is the color that will be applied to the node if no **color property**
@@ -1204,9 +1205,11 @@ components.
     },
     ...
     }
+
     ```
 
     ```
+
 -   `linkCallbacks` **[Array][100]&lt;[Function][101]>** array of callbacks for used defined event handler for link interactions.
 -   `config` **[Object][99]** an object containing rd3g consumer defined configurations [config][118] for the graph.
 -   `highlightedNode` **[string][98]** this value contains a string that represents the some currently highlighted node.

--- a/sandbox/data/static/static.config.js
+++ b/sandbox/data/static/static.config.js
@@ -23,5 +23,6 @@ module.exports = {
     d3: {
         gravity: -400,
         linkLength: 180,
+        disableLinkForce: true,
     },
 };

--- a/src/components/graph/Graph.jsx
+++ b/src/components/graph/Graph.jsx
@@ -183,8 +183,10 @@ export default class Graph extends React.Component {
      * @returns {undefined}
      */
     _graphBindD3ToReactComponent() {
-        this.state.simulation.nodes(this.state.d3Nodes).on("tick", this._tick);
-        this._graphLinkForceConfig();
+        if (!this.state.config.d3.disableLinkForce) {
+            this.state.simulation.nodes(this.state.d3Nodes).on("tick", this._tick);
+            this._graphLinkForceConfig();
+        }
         this._graphNodeDragConfig();
     }
 

--- a/src/components/graph/graph.config.js
+++ b/src/components/graph/graph.config.js
@@ -237,6 +237,7 @@ export default {
         gravity: -100,
         linkLength: 100,
         linkStrength: 1,
+        disableLinkForce: false,
     },
     node: {
         color: "#d3d3d3",


### PR DESCRIPTION
Adding feature discussed in #274 

The example below is the one described in the doc as *small sample config statically positioned nodes.*. However, if we take a look at the picture below, the nodes are not positioned as the user would like since the node config states : 
``` js
{
            id: 3,
            name: "C",
            x: 400,
            y: 100,
        },
        {
            id: 4,
            name: "D",
            x: 400,
            y: 200,
        },
```

And we can see that C and D or not vertically aligned but they should because they have the same x coordinate. 
The option fixes this behavior. 

With `disableLinkForce=false`, before code change: 

![static-false](https://user-images.githubusercontent.com/26838971/70851956-3cae2a80-1e9c-11ea-9840-03b2a405ef97.png)

With `disableLinkForce=true`, with option after code change:
![static-true](https://user-images.githubusercontent.com/26838971/70851975-5ea7ad00-1e9c-11ea-80ae-d1dcfa7c3cf3.png)

I added this option in the static data config, since it's more closer to what the description of the data says. 

