### PR TITLE
Make individual node collapse configurable through "collapsible" prop

### DIFF
--- a/sandbox/Sandbox.jsx
+++ b/sandbox/Sandbox.jsx
@@ -163,7 +163,7 @@ export default class Sandbox extends React.Component {
      * Remove a node.
      */
     onClickRemoveNode = () => {
-        if (this.state.data.nodes && this.state.data.nodes.length) {
+        if (this.state.data.nodes && this.state.data.nodes.length > 1) {
             const id = this.state.data.nodes[0].id;
 
             this.state.data.nodes.splice(0, 1);
@@ -172,7 +172,7 @@ export default class Sandbox extends React.Component {
 
             this.setState({ data });
         } else {
-            toast("No more nodes to remove!");
+            toast("Need to have at least one node!");
         }
     };
 

--- a/src/components/graph/Graph.jsx
+++ b/src/components/graph/Graph.jsx
@@ -9,7 +9,12 @@ import CONST from "./graph.const";
 import DEFAULT_CONFIG from "./graph.config";
 import ERRORS from "../../err";
 
-import { getTargetLeafConnections, toggleLinksMatrixConnections, toggleLinksConnections } from "./collapse.helper";
+import {
+  getTargetLeafConnections,
+  toggleLinksMatrixConnections,
+  toggleLinksConnections,
+  filterNonCollapsibleNodes,
+} from "./collapse.helper";
 import {
     updateNodeHighlightedValue,
     checkForGraphConfigChanges,
@@ -328,9 +333,10 @@ export default class Graph extends React.Component {
     onClickNode = clickedNodeId => {
         if (this.state.config.collapsible) {
             const leafConnections = getTargetLeafConnections(clickedNodeId, this.state.links, this.state.config);
-            const links = toggleLinksMatrixConnections(this.state.links, leafConnections, this.state.config);
+            const filteredLeafConnections = filterNonCollapsibleNodes(this.state.nodes, leafConnections);
+            const links = toggleLinksMatrixConnections(this.state.links, filteredLeafConnections, this.state.config);
             const d3Links = toggleLinksConnections(this.state.d3Links, links);
-            const firstLeaf = leafConnections?.["0"];
+            const firstLeaf = filteredLeafConnections?.["0"];
 
             let isExpanding = false;
 

--- a/src/components/graph/collapse.helper.js
+++ b/src/components/graph/collapse.helper.js
@@ -112,6 +112,24 @@ function getTargetLeafConnections(rootNodeId, linksMatrix = {}, { directed }) {
 }
 
 /**
+ * Filter out leaf connections of nodes which are not collapsible
+ * @param  {Object.<string, Object>} nodes - an object containing all nodes mapped by their id.
+ * @param {Array.<Object.<string, string>>} connections a list of leaf connections.
+ * @returns {Array.<Object.<string, string>>} a list of leaf nodes which are collapsible
+ * @memberof Graph/collapse-helper
+ */
+function filterNonCollapsibleNodes(nodes, connections = []) {
+    return connections.filter(connection => {
+        console.log(connection.target);
+        console.log(nodes[connection.target]);
+        const leafNode = nodes[connection.target];
+
+        return Object.hasOwnProperty.call(leafNode, "collapsible") ? leafNode.collapsible : true;
+
+    });
+}
+
+/**
  * Given a node and the connections matrix, check if node should be displayed
  * NOTE: this function is meant to be used under the `collapsible` toggle, meaning
  * that the `isNodeVisible` actually is checking visibility on collapsible graphs.
@@ -195,4 +213,5 @@ export {
     isNodeVisible,
     toggleLinksConnections,
     toggleLinksMatrixConnections,
+    filterNonCollapsibleNodes,
 };


### PR DESCRIPTION
Nodes can be passed a boolean `collapsible` prop. By default, each node is collapsible. However, if `collapsible` is set to false for a node, that node will not disappear on collapse even if it is a leaf node.
Closes https://github.com/danielcaldas/react-d3-graph/issues/168.