### PR TITLE
Added ability to configure a node's width and height separately

### DIFF
--- a/sandbox/utils.js
+++ b/sandbox/utils.js
@@ -37,7 +37,7 @@ function generateFormSchema(o, rootSpreadProp, accum = {}) {
         const kk = rootSpreadProp ? `${rootSpreadProp}.${k}` : k;
 
         if (o[k] !== undefined && o[k] !== null && typeof o[k] !== "function") {
-            typeof o[k] === "object" ? generateFormSchema(o[kk], kk, accum) : (accum[kk] = formMap(kk, o[k]));
+            typeof o[k] === "object" ? generateFormSchema(o[k], kk, accum) : (accum[kk] = formMap(kk, o[k]));
         }
     }
 

--- a/src/components/graph/graph.builder.js
+++ b/src/components/graph/graph.builder.js
@@ -170,7 +170,7 @@ function buildNodeProps(node, config, nodeCallbacks = {}, highlightedNode, highl
     const highlight =
         node.highlighted ||
         node.id === (highlightedLink && highlightedLink.source) ||
-            node.id === (highlightedLink && highlightedLink.target);
+        node.id === (highlightedLink && highlightedLink.target);
     const opacity = _getNodeOpacity(node, highlightedNode, highlightedLink, config);
 
     let fill = node.color || config.node.color;
@@ -203,8 +203,9 @@ function buildNodeProps(node, config, nodeCallbacks = {}, highlightedNode, highl
     const nodeSize = node.size || config.node.size;
 
     let offset;
+    const isSizeNumericValue = typeof nodeSize !== "object";
 
-    if (typeof nodeSize !== "object") {
+    if (isSizeNumericValue) {
         offset = nodeSize;
     } else if (labelPosition === "top" || labelPosition === "bottom") {
         offset = nodeSize.height;
@@ -234,7 +235,7 @@ function buildNodeProps(node, config, nodeCallbacks = {}, highlightedNode, highl
         opacity,
         overrideGlobalViewGenerator: !node.viewGenerator && node.svg,
         renderLabel: node.renderLabel || config.node.renderLabel,
-        size: typeof nodeSize !== "object" ? nodeSize * t : { height: nodeSize.height * t, width: nodeSize.width * t },
+        size: isSizeNumericValue ? nodeSize * t : { height: nodeSize.height * t, width: nodeSize.width * t },
         stroke,
         strokeWidth: strokeWidth * t,
         svg,

--- a/src/components/graph/graph.builder.js
+++ b/src/components/graph/graph.builder.js
@@ -169,8 +169,8 @@ function buildLinkProps(link, nodes, links, config, linkCallbacks, highlightedNo
 function buildNodeProps(node, config, nodeCallbacks = {}, highlightedNode, highlightedLink, transform) {
     const highlight =
         node.highlighted ||
-        (node.id === (highlightedLink && highlightedLink.source) ||
-            node.id === (highlightedLink && highlightedLink.target));
+        node.id === (highlightedLink && highlightedLink.source) ||
+            node.id === (highlightedLink && highlightedLink.target);
     const opacity = _getNodeOpacity(node, highlightedNode, highlightedLink, config);
 
     let fill = node.color || config.node.color;
@@ -201,8 +201,19 @@ function buildNodeProps(node, config, nodeCallbacks = {}, highlightedNode, highl
 
     const t = 1 / transform;
     const nodeSize = node.size || config.node.size;
+
+    let offset;
+
+    if (typeof nodeSize !== "object") {
+        offset = nodeSize;
+    } else if (labelPosition === "top" || labelPosition === "bottom") {
+        offset = nodeSize.height;
+    } else {
+        nodeSize.width;
+    }
+
     const fontSize = highlight ? config.node.highlightFontSize : config.node.fontSize;
-    const dx = fontSize * t + nodeSize / 100 + 1.5;
+    const dx = fontSize * t + offset / 100 + 1.5;
     const svg = node.svg || config.node.svg;
     const fontColor = node.fontColor || config.node.fontColor;
 
@@ -223,7 +234,7 @@ function buildNodeProps(node, config, nodeCallbacks = {}, highlightedNode, highl
         opacity,
         overrideGlobalViewGenerator: !node.viewGenerator && node.svg,
         renderLabel: node.renderLabel || config.node.renderLabel,
-        size: nodeSize * t,
+        size: typeof nodeSize !== "object" ? nodeSize * t : { height: nodeSize.height * t, width: nodeSize.width * t },
         stroke,
         strokeWidth: strokeWidth * t,
         svg,

--- a/src/components/graph/graph.config.js
+++ b/src/components/graph/graph.config.js
@@ -146,7 +146,16 @@
  * @param {number} [node.opacity=1] - <a id="node-opacity" href="#node-opacity">🔗</a> 🔍🔍🔍 by default all nodes will have this opacity value.
  * @param {boolean} [node.renderLabel=true] - <a id="node-render-label" href="#node-render-label">🔗</a> 🔍🔍🔍 when set to false no labels will appear along side nodes in the
  * graph.
- * @param {number} [node.size=200] - <a id="node-size" href="#node-size">🔗</a> 🔍🔍🔍 defines the size of all nodes.
+ * @param {number|Object} [node.size=200] - <a id="node-size" href="#node-size">🔗</a> 🔍🔍🔍 defines the size of all nodes. When set to a number, the node will have equal height and width.</br>
+ * This can also be an object with a height and width property <b>when using custom nodes</b>.
+ * ```javascript
+ * size: 200
+ * // or
+ * size: {
+ *    height: 200,
+ *    width: 300,
+ * }
+ * ```
  * @param {string} [node.strokeColor="none"] - <a id="node-stroke-color" href="#node-stroke-color">🔗</a> 🔍🔍🔍  this is the stroke color that will be applied to the node if no <b>strokeColor property</b> is found inside the node itself (yes <b>you can pass a property "strokeColor" inside the node and that stroke color will override this default one</b>).
  * @param {number} [node.strokeWidth=1.5] - <a id="node-stroke-width" href="#node-stroke-width">🔗</a> 🔍🔍🔍 the width of the all node strokes.
  * @param {string} [node.svg=""] - <a id="node-svg" href="#node-svg">🔗</a> 🔍🔍🔍 render custom svg for nodes in alternative to <b>node.symbolType</b>. This svg can

--- a/src/components/graph/graph.config.js
+++ b/src/components/graph/graph.config.js
@@ -156,6 +156,7 @@
  *    width: 300,
  * }
  * ```
+ * The actual node dimensions (in px) rendered on screen will be the size value divided by 10. For example, a node size of 200 will result in a node with a height and width of 20px.
  * @param {string} [node.strokeColor="none"] - <a id="node-stroke-color" href="#node-stroke-color">🔗</a> 🔍🔍🔍  this is the stroke color that will be applied to the node if no <b>strokeColor property</b> is found inside the node itself (yes <b>you can pass a property "strokeColor" inside the node and that stroke color will override this default one</b>).
  * @param {number} [node.strokeWidth=1.5] - <a id="node-stroke-width" href="#node-stroke-width">🔗</a> 🔍🔍🔍 the width of the all node strokes.
  * @param {string} [node.svg=""] - <a id="node-svg" href="#node-svg">🔗</a> 🔍🔍🔍 render custom svg for nodes in alternative to <b>node.symbolType</b>. This svg can

--- a/src/components/node/Node.jsx
+++ b/src/components/node/Node.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import nodeHelper from "./node.helper";
+import CONST from "./node.const";
 
 /**
  * Node component is responsible for encapsulating node render.
@@ -94,7 +95,7 @@ export default class Node extends React.Component {
             opacity: this.props.opacity,
         };
 
-        const size = this.props.size;
+        let size = this.props.size;
 
         let gtx = this.props.cx,
             gty = this.props.cy,
@@ -102,8 +103,8 @@ export default class Node extends React.Component {
             node = null;
 
         if (this.props.svg || this.props.viewGenerator) {
-            const height = size / 10;
-            const width = size / 10;
+            const height = typeof size === "object" ? size.height / 10 : size / 10;
+            const width = typeof size === "object" ? size.width / 10 : size / 10;
             const tx = width / 2;
             const ty = height / 2;
             const transform = `translate(${tx},${ty})`;
@@ -133,6 +134,10 @@ export default class Node extends React.Component {
             gtx -= tx;
             gty -= ty;
         } else {
+            if (typeof size === "object") {
+                console.warn("node.size should be a number when not using custom nodes.");
+                size = CONST.DEFAULT_NODE_SIZE;
+            }
             nodeProps.d = nodeHelper.buildSvgSymbol(size, this.props.type);
             nodeProps.fill = this.props.fill;
             nodeProps.stroke = this.props.stroke;

--- a/src/components/node/Node.jsx
+++ b/src/components/node/Node.jsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import nodeHelper from "./node.helper";
 import CONST from "./node.const";
+import { logWarning } from "../../utils";
 
 /**
  * Node component is responsible for encapsulating node render.
@@ -96,6 +97,7 @@ export default class Node extends React.Component {
         };
 
         let size = this.props.size;
+        const isSizeNumericalValue = typeof size !== "object";
 
         let gtx = this.props.cx,
             gty = this.props.cy,
@@ -103,8 +105,8 @@ export default class Node extends React.Component {
             node = null;
 
         if (this.props.svg || this.props.viewGenerator) {
-            const height = typeof size === "object" ? size.height / 10 : size / 10;
-            const width = typeof size === "object" ? size.width / 10 : size / 10;
+            const height = isSizeNumericalValue ? size / 10 : size.height / 10;
+            const width = isSizeNumericalValue ? size / 10 : size.width / 10;
             const tx = width / 2;
             const ty = height / 2;
             const transform = `translate(${tx},${ty})`;
@@ -134,8 +136,8 @@ export default class Node extends React.Component {
             gtx -= tx;
             gty -= ty;
         } else {
-            if (typeof size === "object") {
-                console.warn("node.size should be a number when not using custom nodes.");
+            if (!isSizeNumericalValue) {
+                logWarning("node.size should be a number when not using custom nodes.");
                 size = CONST.DEFAULT_NODE_SIZE;
             }
             nodeProps.d = nodeHelper.buildSvgSymbol(size, this.props.type);


### PR DESCRIPTION
From #336, added the ability to configure a node's width and height separately when using custom nodes. For example:
```javascript
node:  {
    size: {
        width: 300,
        height: 200,
    },
}
```
This does not break any existing configurations. Using this with the standard node shapes will cause the links to disappear, however there is no reason to use a different height and width for these anyways since the d3 shapes cannot be stretched. I explicitly stated that this should only be used for custom nodes in the documentation, as well as added a `console.warn()` to discourage this incorrect use.

I think this is an important feature for people who want to use custom nodes because when using a custom node with an unequal height and width, unnecessary white space has to be added in order for the node to not be cut off. For example:

![react-d3-graph-node-size-pull](https://user-images.githubusercontent.com/23760949/86201913-aa0e6980-bb15-11ea-9f21-2bc0ee25f349.gif)

Let me know your thoughts on this!
