### PR TITLE
allow dashed links

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -524,6 +524,9 @@ const graph = {
         This is how link strokeWidth will be calculated:`javascript strokeWidth += (linkValue * strokeWidth) / 10;` (optional, default `false`)
     -   `link.strokeWidth` **[number][181]** <a id="link-stroke-width" href="#link-stroke-width">🔗</a> 🔍🔍🔍 strokeWidth for all links. By default the actual value is obtain by the
         following expression:`javascript link.strokeWidth * (1 / transform); // transform is a zoom delta Δ value` (optional, default `1.5`)
+    -   `link.strokeDasharray` **[string][183]** <a id="link-stroke-dasharray" href="#link-stroke-dasharray">🔗</a> 🔍🔍🔍 strokeDasharray for all links.
+    -   `link.strokeDashoffset` **[number][181]** <a id="link-stroke-dashoffset" href="#link-stroke-dashoffset">🔗</a> 🔍🔍🔍 strokeDashoffset for all links.
+    -   `link.strokeLinecap` **[string][183]** <a id="link-stroke-linecap" href="#link-stroke-linecap">🔗</a> 🔍🔍🔍 strokeLinecap for all links.
     -   `link.markerHeight` **[number][181]** <a id="link-marker-height" href="#link-marker-height">🔗</a> <a target="_blank" href="https://developer.mozilla.org/en/docs/Web/SVG/Attribute/markerHeight">markerHeight</a>
         property for the link arrowhead height. _Note: this property can only be set in the first mount, it does not update dynamically._ (optional, default `6`)
     -   `link.markerWidth` **[number][181]** <a id="link-marker-width" href="#link-marker-width">🔗</a> <a target="_blank" href="https://developer.mozilla.org/en/docs/Web/SVG/Attribute/markerWidth">markerWidth</a>
@@ -1387,9 +1390,11 @@ components.
     },
     ...
     }
+
     ```
 
     ```
+
 -   `linkCallbacks` **[Array][185]&lt;[Function][186]>** array of callbacks for used defined event handler for link interactions.
 -   `config` **[Object][184]** an object containing rd3g consumer defined configurations [config][195] for the graph.
 -   `highlightedNode` **[string][183]** this value contains a string that represents the some currently highlighted node.

--- a/src/components/graph/graph.builder.js
+++ b/src/components/graph/graph.builder.js
@@ -94,6 +94,9 @@ function buildLinkProps(link, nodes, links, config, linkCallbacks, highlightedNo
     }
 
     let strokeWidth = (link.strokeWidth || config.link.strokeWidth) * (1 / transform);
+    let strokeDasharray = link.strokeDasharray || config.link.strokeDasharray;
+    let strokeDashoffset = link.strokeDashoffset || config.link.strokeDashoffset;
+    let strokeLinecap = link.strokeLinecap || config.link.strokeLinecap;
 
     if (config.link.semanticStrokeWidth) {
         const linkValue = links[source][target] || links[target][source] || 1;
@@ -143,6 +146,9 @@ function buildLinkProps(link, nodes, links, config, linkCallbacks, highlightedNo
         source,
         stroke,
         strokeWidth,
+        strokeDasharray,
+        strokeDashoffset,
+        strokeLinecap,
         target,
         onClickLink: linkCallbacks.onClickLink,
         onMouseOutLink: linkCallbacks.onMouseOutLink,

--- a/src/components/link/Link.jsx
+++ b/src/components/link/Link.jsx
@@ -26,6 +26,9 @@ import React from "react";
  *     markerId="marker-small"
  *     strokeWidth=1.5
  *     stroke="green"
+ *     strokeDasharray="5 1"
+ *     strokeDashoffset="3"
+ *     strokeLinecap="round"
  *     className="link"
  *     opacity=1
  *     mouseCursor="pointer"
@@ -65,11 +68,14 @@ export default class Link extends React.Component {
 
     render() {
         const lineStyle = {
-            strokeWidth: this.props.strokeWidth,
             stroke: this.props.stroke,
+            strokeWidth: this.props.strokeWidth,
+            strokeDasharray: this.props.strokeDasharray,
+            strokeDashoffset: this.props.strokeDasharray,
+            strokeLinecap: this.props.strokeLinecap,
             opacity: this.props.opacity,
-            fill: "none",
             cursor: this.props.mouseCursor,
+            fill: "none",
         };
 
         const lineProps = {

--- a/test/graph/__snapshots__/graph.snapshot.spec.js.snap
+++ b/test/graph/__snapshots__/graph.snapshot.spec.js.snap
@@ -130,6 +130,9 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
               "fill": "none",
               "opacity": 1,
               "stroke": "#d3d3d3",
+              "strokeDasharray": undefined,
+              "strokeDashoffset": undefined,
+              "strokeLinecap": undefined,
               "strokeWidth": 1.5,
             }
           }
@@ -150,6 +153,9 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
               "fill": "none",
               "opacity": 1,
               "stroke": "#d3d3d3",
+              "strokeDasharray": undefined,
+              "strokeDashoffset": undefined,
+              "strokeLinecap": undefined,
               "strokeWidth": 1.5,
             }
           }
@@ -170,6 +176,9 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
               "fill": "none",
               "opacity": 1,
               "stroke": "#d3d3d3",
+              "strokeDasharray": undefined,
+              "strokeDashoffset": undefined,
+              "strokeLinecap": undefined,
               "strokeWidth": 1.5,
             }
           }
@@ -190,6 +199,9 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
               "fill": "none",
               "opacity": 1,
               "stroke": "#d3d3d3",
+              "strokeDasharray": undefined,
+              "strokeDashoffset": undefined,
+              "strokeLinecap": undefined,
               "strokeWidth": 1.5,
             }
           }
@@ -210,6 +222,9 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
               "fill": "none",
               "opacity": 1,
               "stroke": "#d3d3d3",
+              "strokeDasharray": undefined,
+              "strokeDashoffset": undefined,
+              "strokeLinecap": undefined,
               "strokeWidth": 1.5,
             }
           }
@@ -230,6 +245,9 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
               "fill": "none",
               "opacity": 1,
               "stroke": "#d3d3d3",
+              "strokeDasharray": undefined,
+              "strokeDashoffset": undefined,
+              "strokeLinecap": undefined,
               "strokeWidth": 1.5,
             }
           }
@@ -250,6 +268,9 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
               "fill": "none",
               "opacity": 1,
               "stroke": "#d3d3d3",
+              "strokeDasharray": undefined,
+              "strokeDashoffset": undefined,
+              "strokeLinecap": undefined,
               "strokeWidth": 1.5,
             }
           }
@@ -270,6 +291,9 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
               "fill": "none",
               "opacity": 1,
               "stroke": "#d3d3d3",
+              "strokeDasharray": undefined,
+              "strokeDashoffset": undefined,
+              "strokeLinecap": undefined,
               "strokeWidth": 1.5,
             }
           }
@@ -290,6 +314,9 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
               "fill": "none",
               "opacity": 1,
               "stroke": "#d3d3d3",
+              "strokeDasharray": undefined,
+              "strokeDashoffset": undefined,
+              "strokeLinecap": undefined,
               "strokeWidth": 1.5,
             }
           }
@@ -310,6 +337,9 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
               "fill": "none",
               "opacity": 1,
               "stroke": "#d3d3d3",
+              "strokeDasharray": undefined,
+              "strokeDashoffset": undefined,
+              "strokeLinecap": undefined,
               "strokeWidth": 1.5,
             }
           }
@@ -330,6 +360,9 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
               "fill": "none",
               "opacity": 1,
               "stroke": "#d3d3d3",
+              "strokeDasharray": undefined,
+              "strokeDashoffset": undefined,
+              "strokeLinecap": undefined,
               "strokeWidth": 1.5,
             }
           }
@@ -350,6 +383,9 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
               "fill": "none",
               "opacity": 1,
               "stroke": "#d3d3d3",
+              "strokeDasharray": undefined,
+              "strokeDashoffset": undefined,
+              "strokeLinecap": undefined,
               "strokeWidth": 1.5,
             }
           }
@@ -370,6 +406,9 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
               "fill": "none",
               "opacity": 1,
               "stroke": "#d3d3d3",
+              "strokeDasharray": undefined,
+              "strokeDashoffset": undefined,
+              "strokeLinecap": undefined,
               "strokeWidth": 1.5,
             }
           }
@@ -390,6 +429,9 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
               "fill": "none",
               "opacity": 1,
               "stroke": "#d3d3d3",
+              "strokeDasharray": undefined,
+              "strokeDashoffset": undefined,
+              "strokeLinecap": undefined,
               "strokeWidth": 1.5,
             }
           }
@@ -410,6 +452,9 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
               "fill": "none",
               "opacity": 1,
               "stroke": "#d3d3d3",
+              "strokeDasharray": undefined,
+              "strokeDashoffset": undefined,
+              "strokeLinecap": undefined,
               "strokeWidth": 1.5,
             }
           }
@@ -430,6 +475,9 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
               "fill": "none",
               "opacity": 1,
               "stroke": "#d3d3d3",
+              "strokeDasharray": undefined,
+              "strokeDashoffset": undefined,
+              "strokeLinecap": undefined,
               "strokeWidth": 1.5,
             }
           }
@@ -450,6 +498,9 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
               "fill": "none",
               "opacity": 1,
               "stroke": "#d3d3d3",
+              "strokeDasharray": undefined,
+              "strokeDashoffset": undefined,
+              "strokeLinecap": undefined,
               "strokeWidth": 1.5,
             }
           }
@@ -470,6 +521,9 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
               "fill": "none",
               "opacity": 1,
               "stroke": "#d3d3d3",
+              "strokeDasharray": undefined,
+              "strokeDashoffset": undefined,
+              "strokeLinecap": undefined,
               "strokeWidth": 1.5,
             }
           }
@@ -490,6 +544,9 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
               "fill": "none",
               "opacity": 1,
               "stroke": "#d3d3d3",
+              "strokeDasharray": undefined,
+              "strokeDashoffset": undefined,
+              "strokeLinecap": undefined,
               "strokeWidth": 1.5,
             }
           }
@@ -510,6 +567,9 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
               "fill": "none",
               "opacity": 1,
               "stroke": "#d3d3d3",
+              "strokeDasharray": undefined,
+              "strokeDashoffset": undefined,
+              "strokeLinecap": undefined,
               "strokeWidth": 1.5,
             }
           }
@@ -530,6 +590,9 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
               "fill": "none",
               "opacity": 1,
               "stroke": "#d3d3d3",
+              "strokeDasharray": undefined,
+              "strokeDashoffset": undefined,
+              "strokeLinecap": undefined,
               "strokeWidth": 1.5,
             }
           }
@@ -550,6 +613,9 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
               "fill": "none",
               "opacity": 1,
               "stroke": "#d3d3d3",
+              "strokeDasharray": undefined,
+              "strokeDashoffset": undefined,
+              "strokeLinecap": undefined,
               "strokeWidth": 1.5,
             }
           }
@@ -570,6 +636,9 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
               "fill": "none",
               "opacity": 1,
               "stroke": "#d3d3d3",
+              "strokeDasharray": undefined,
+              "strokeDashoffset": undefined,
+              "strokeLinecap": undefined,
               "strokeWidth": 1.5,
             }
           }
@@ -590,6 +659,9 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
               "fill": "none",
               "opacity": 1,
               "stroke": "#d3d3d3",
+              "strokeDasharray": undefined,
+              "strokeDashoffset": undefined,
+              "strokeLinecap": undefined,
               "strokeWidth": 1.5,
             }
           }
@@ -610,6 +682,9 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
               "fill": "none",
               "opacity": 1,
               "stroke": "#d3d3d3",
+              "strokeDasharray": undefined,
+              "strokeDashoffset": undefined,
+              "strokeLinecap": undefined,
               "strokeWidth": 1.5,
             }
           }
@@ -630,6 +705,9 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
               "fill": "none",
               "opacity": 1,
               "stroke": "#d3d3d3",
+              "strokeDasharray": undefined,
+              "strokeDashoffset": undefined,
+              "strokeLinecap": undefined,
               "strokeWidth": 1.5,
             }
           }
@@ -650,6 +728,9 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
               "fill": "none",
               "opacity": 1,
               "stroke": "#d3d3d3",
+              "strokeDasharray": undefined,
+              "strokeDashoffset": undefined,
+              "strokeLinecap": undefined,
               "strokeWidth": 1.5,
             }
           }
@@ -670,6 +751,9 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
               "fill": "none",
               "opacity": 1,
               "stroke": "#d3d3d3",
+              "strokeDasharray": undefined,
+              "strokeDashoffset": undefined,
+              "strokeLinecap": undefined,
               "strokeWidth": 1.5,
             }
           }

--- a/test/link/__snapshots__/link.snapshot.spec.js.snap
+++ b/test/link/__snapshots__/link.snapshot.spec.js.snap
@@ -13,6 +13,9 @@ exports[`Snapshot - Link Component should match snapshot 1`] = `
         "fill": "none",
         "opacity": "1",
         "stroke": "red",
+        "strokeDasharray": undefined,
+        "strokeDashoffset": undefined,
+        "strokeLinecap": undefined,
         "strokeWidth": "2",
       }
     }


### PR DESCRIPTION
Closes https://github.com/danielcaldas/react-d3-graph/issues/343

This little change gives the user more control on the appearance of the links, adding support for `stroke-dasharray`, `stroke-dashoffset` and `stroke-linecap` svg attributes.
As for already supported attributes, they can be defined on single links or globally.