### PR TITLE
Use fx and fy when initializing nodes

### DIFF
--- a/src/components/graph/graph.helper.js
+++ b/src/components/graph/graph.helper.js
@@ -111,11 +111,17 @@ function _initializeNodes(graphNodes) {
 
         node.highlighted = false;
 
-        if (!Object.prototype.hasOwnProperty.call(node, "x")) {
+        // if an fx (forced x) is given, we want to use that
+        if (Object.prototype.hasOwnProperty.call(node, "fx")) {
+            node.x = node.fx;
+        } else if (!Object.prototype.hasOwnProperty.call(node, "x")) {
             node.x = 0;
         }
 
-        if (!Object.prototype.hasOwnProperty.call(node, "y")) {
+        // if an fy (forced y) is given, we want to use that
+        if (Object.prototype.hasOwnProperty.call(node, "fy")) {
+            node.y = node.fy;
+        } else if (!Object.prototype.hasOwnProperty.call(node, "y")) {
             node.y = 0;
         }
 

--- a/test/graph/graph.helper.spec.js
+++ b/test/graph/graph.helper.spec.js
@@ -36,7 +36,10 @@ describe("Graph Helper", () => {
                 test("should create graph structure absorbing stored nodes and links behavior", () => {
                     const data = {
                         nodes: [{ id: "A" }, { id: "B" }, { id: "C" }],
-                        links: [{ source: "A", target: "B" }, { source: "C", target: "A" }],
+                        links: [
+                            { source: "A", target: "B" },
+                            { source: "C", target: "A" },
+                        ],
                     };
                     const state = {
                         nodes: {
@@ -120,7 +123,10 @@ describe("Graph Helper", () => {
                 test("should create new graph structure with nodes and links", () => {
                     const data = {
                         nodes: [{ id: "A" }, { id: "B" }, { id: "C" }],
-                        links: [{ source: "A", target: "B" }, { source: "C", target: "A" }],
+                        links: [
+                            { source: "A", target: "B" },
+                            { source: "C", target: "A" },
+                        ],
                     };
                     const state = {};
 
@@ -147,13 +153,17 @@ describe("Graph Helper", () => {
                 });
 
                 const data = {
-                    nodes: [{ id: "A" }, { id: "B" }, { id: "C" }],
-                    links: [{ source: "A", target: "B" }, { source: "C", target: "A" }],
+                    nodes: [{ id: "A" }, { id: "B" }, { id: "C" }, { id: "D", fx: 80, fy: 100 }],
+                    links: [
+                        { source: "A", target: "B" },
+                        { source: "C", target: "A" },
+                    ],
                 };
                 const state = {
                     nodes: {
                         A: { x: 20, y: 40 },
                         B: { x: 40, y: 60 },
+                        D: { fx: 80, fy: 100 },
                     },
                     links: "links",
                     nodeIndexMapping: "nodeIndexMapping",
@@ -209,6 +219,15 @@ describe("Graph Helper", () => {
                             x: 0,
                             y: 0,
                         },
+                        {
+                            // the fx and fy here are used to set the node's x and y
+                            fx: 80,
+                            fy: 100,
+                            highlighted: false,
+                            id: "D",
+                            x: 80,
+                            y: 100,
+                        },
                     ],
                     highlightedNode: "",
                     id: "id",
@@ -243,6 +262,15 @@ describe("Graph Helper", () => {
                             id: "C",
                             x: 0,
                             y: 0,
+                        },
+                        D: {
+                            _orphan: true,
+                            fx: 80,
+                            fy: 100,
+                            highlighted: false,
+                            id: "D",
+                            x: 80,
+                            y: 100,
                         },
                     },
                     simulation: {


### PR DESCRIPTION
Fixes #350, fixes #295

Tested by setting `sandbox/data/default.js` to the following:

```js
module.exports = {
    nodes: [
        {
            id: "node-1",
            fx: 100,
            fy: 100,
        },
        {
            id: "node-2",
            fx: 200,
            fy: 200,
        },
        {
            id: "node-3",
            fx: 300,
            fy: 300,
        },
    ],
    links: [
        {
            source: "node-1",
            target: "node-2",
        },
    ],
};

```

Before this change, `node-3` would render in a different spot every time the page was refreshed.

With this change it always renders at `300,300`.