### PR TITLE
Fix to change arrow color when link color or highlight color changes

### DIFF
--- a/cypress/integration/graph.directed.e2e.js
+++ b/cypress/integration/graph.directed.e2e.js
@@ -3,6 +3,7 @@ const SANDBOX_URL = Cypress.env("SANDBOX_URL");
 const LinkPO = require("../page-objects/link.po");
 const NodePO = require("../page-objects/node.po");
 const SandboxPO = require("../page-objects/sandbox.po");
+const MarkerPO = require("../page-objects/marker.po");
 
 describe("[rd3g-graph-directed]", function() {
     beforeEach(function() {
@@ -168,6 +169,83 @@ describe("[rd3g-graph-directed]", function() {
             this.link14PO.hasMarker();
             this.link34PO.getLine().should("be.visible");
             this.link34PO.hasMarker();
+        });
+    });
+
+    describe("check graph markers", function() {
+        beforeEach(function() {
+            this.markerSmall = new MarkerPO("marker-small");
+            this.markerSmallHighlighted = new MarkerPO("marker-small-highlighted");
+            this.markerMedium = new MarkerPO("marker-medium");
+            this.markerMediumHighlighted = new MarkerPO("marker-medium-highlighted");
+            this.markerLarge = new MarkerPO("marker-large");
+            this.markerLargeHighlighted = new MarkerPO("marker-large-highlighted");
+        });
+
+        afterEach(function() {
+            // Reset link.color and link.highlightColor
+            cy.contains("link.color").scrollIntoView();
+            this.sandboxPO
+                .getFieldInput("link.color")
+                .clear()
+                .type("#d3d3d3");
+
+            cy.contains("link.highlightColor").scrollIntoView();
+            this.sandboxPO
+                .getFieldInput("link.highlightColor")
+                .clear()
+                .type("blue");
+        });
+
+        it("should correctly render inital marker colors", function() {
+            this.markerSmall.getColor().should("eq", "#d3d3d3");
+            this.markerSmallHighlighted.getColor().should("eq", "blue");
+            this.markerMedium.getColor().should("eq", "#d3d3d3");
+            this.markerMediumHighlighted.getColor().should("eq", "blue");
+            this.markerLarge.getColor().should("eq", "#d3d3d3");
+            this.markerLargeHighlighted.getColor().should("eq", "blue");
+        });
+
+        it("should correctly render marker colors based on current link.color and link.highlightColor", function() {
+            cy.contains("link.color").scrollIntoView();
+            this.sandboxPO
+                .getFieldInput("link.color")
+                .clear()
+                .type("rgba(255,0,0,0.9)");
+
+            cy.contains("link.highlightColor").scrollIntoView();
+            this.sandboxPO
+                .getFieldInput("link.highlightColor")
+                .clear()
+                .type("green");
+
+            this.markerSmall.getColor().should("eq", "rgba(255,0,0,0.9)");
+            this.markerSmallHighlighted.getColor().should("eq", "green");
+            this.markerMedium.getColor().should("eq", "rgba(255,0,0,0.9)");
+            this.markerMediumHighlighted.getColor().should("eq", "green");
+            this.markerLarge.getColor().should("eq", "rgba(255,0,0,0.9)");
+            this.markerLargeHighlighted.getColor().should("eq", "green");
+        });
+
+        it("should correctly render marker colors when link.highlightColor is SAME", function() {
+            cy.contains("link.color").scrollIntoView();
+            this.sandboxPO
+                .getFieldInput("link.color")
+                .clear()
+                .type("green");
+
+            cy.contains("link.highlightColor").scrollIntoView();
+            this.sandboxPO
+                .getFieldInput("link.highlightColor")
+                .clear()
+                .type("SAME");
+
+            this.markerSmall.getColor().should("eq", "green");
+            this.markerSmallHighlighted.getColor().should("eq", "green");
+            this.markerMedium.getColor().should("eq", "green");
+            this.markerMediumHighlighted.getColor().should("eq", "green");
+            this.markerLarge.getColor().should("eq", "green");
+            this.markerLargeHighlighted.getColor().should("eq", "green");
         });
     });
 });

--- a/cypress/page-objects/marker.po.js
+++ b/cypress/page-objects/marker.po.js
@@ -1,0 +1,12 @@
+/**
+ * Page Object for interacting with Marker component.
+ * @param {string} id - the id of the marker.
+ * @returns {undefined}
+ */
+function MarkerPO(id) {
+    this.id = id;
+    this.marker = `#${this.id}`;
+    this.getColor = () => cy.get(this.marker).invoke("attr", "fill");
+}
+
+module.exports = MarkerPO;

--- a/src/components/graph/graph.renderer.jsx
+++ b/src/components/graph/graph.renderer.jsx
@@ -99,31 +99,37 @@ function _renderNodes(nodes, nodeCallbacks, config, highlightedNode, highlighted
  * @memberof Graph/renderer
  */
 function _renderDefs() {
-    let cachedDefs;
+    let markerCache = {};
 
     return config => {
-        if (cachedDefs) {
-            return cachedDefs;
+        const highlightColor =
+            !config.link.highlightColor || config.link.highlightColor === "SAME"
+                ? config.link.color
+                : config.link.highlightColor;
+        const color = config.link.color;
+
+        const key = `${color}___${highlightColor}`;
+
+        if (!markerCache[key]) {
+            const { small, medium, large } = getMarkerSize(config);
+            const markerProps = {
+                markerWidth: config.link.markerWidth,
+                markerHeight: config.link.markerHeight,
+            };
+
+            markerCache[key] = (
+                <defs>
+                    <Marker id={MARKERS.MARKER_S} refX={small} fill={color} {...markerProps} />
+                    <Marker id={MARKERS.MARKER_SH} refX={small} fill={highlightColor} {...markerProps} />
+                    <Marker id={MARKERS.MARKER_M} refX={medium} fill={color} {...markerProps} />
+                    <Marker id={MARKERS.MARKER_MH} refX={medium} fill={highlightColor} {...markerProps} />
+                    <Marker id={MARKERS.MARKER_L} refX={large} fill={color} {...markerProps} />
+                    <Marker id={MARKERS.MARKER_LH} refX={large} fill={highlightColor} {...markerProps} />
+                </defs>
+            );
         }
 
-        const { small, medium, large } = getMarkerSize(config);
-        const markerProps = {
-            markerWidth: config.link.markerWidth,
-            markerHeight: config.link.markerHeight,
-        };
-
-        cachedDefs = (
-            <defs>
-                <Marker id={MARKERS.MARKER_S} refX={small} fill={config.link.color} {...markerProps} />
-                <Marker id={MARKERS.MARKER_SH} refX={small} fill={config.link.highlightColor} {...markerProps} />
-                <Marker id={MARKERS.MARKER_M} refX={medium} fill={config.link.color} {...markerProps} />
-                <Marker id={MARKERS.MARKER_MH} refX={medium} fill={config.link.highlightColor} {...markerProps} />
-                <Marker id={MARKERS.MARKER_L} refX={large} fill={config.link.color} {...markerProps} />
-                <Marker id={MARKERS.MARKER_LH} refX={large} fill={config.link.highlightColor} {...markerProps} />
-            </defs>
-        );
-
-        return cachedDefs;
+        return markerCache[key];
     };
 }
 


### PR DESCRIPTION
closes #360 

Issue https://github.com/danielcaldas/react-d3-graph/issues/360
---
Our application allow user to choose between light and dark theme. We set link color and highlight color to text color for theme. When the graph is loaded initially, both link and arrow color are in sync. But when user switches theme, the arrow color remain same, giving a bad user experience.

Change Detail
---
- Current code assumes that `defs` are static and they need not be changed ever after the graph is loaded.
- Current code caches the defs based on initial render and always returns cached copy of `defs`
- Changed the code to maintain a cache for `link.color` and `link.highlightColor` combinations
- A new cache key is added for each combination of  `link.color` and `link.highlightColor`
- `defs` are returned from cache, if it already exists in cache
- Added e2e tests to validate that the changes indeed fix the issue https://github.com/danielcaldas/react-d3-graph/issues/360. These tests fail currently
- See screenshots after fix

Screenshot
---
- Link and arrow color mismatch in normal mode

<img width="1675" alt="Screen Shot 2020-08-27 at 10 22 22 AM" src="https://user-images.githubusercontent.com/46772616/91474683-6606bf00-e84f-11ea-8245-af3f768526b3.png">

- Link and arrow color mismatch when hover over node/link

<img width="1678" alt="Screen Shot 2020-08-27 at 10 22 48 AM" src="https://user-images.githubusercontent.com/46772616/91474761-8171ca00-e84f-11ea-8f7a-13e3ffb97ae7.png">
