### PR TITLE
Bug fix around node offset improvement for arrow positioning #271

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,8 @@ module.exports = {
     window: true,
     __dirname: true,
     process: true,
+    Map: true,
+    Set: true,
   },
   parser: "babel-eslint",
   parserOptions: {

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -15,7 +15,10 @@ This is not yet a full automated process, so here are a few steps to get the thi
 3.  npm run docs
 4.  Small tweaks on documentation page (quicklinks)
 5.  Replace current files in docs for the generated ones in gen-docs
-6.  Generate CHANGELOG.md (github_changelog_generator -u GITHUB_USERNAME)
+6.  Generate CHANGELOG.md
+    ```bash
+        github_changelog_generator since-tag=<PREVIOUS_RELEASED_VERSION> -u GITHUB_USERNAME
+    ```
 7.  git commit -m "Release x.x.x"
 8.  Create release x.x.x in github
 9.  git pull (origin master)

--- a/src/components/graph/graph.builder.js
+++ b/src/components/graph/graph.builder.js
@@ -121,13 +121,13 @@ function buildLinkProps(link, nodes, links, config, linkCallbacks, highlightedNo
     fontWeight = highlight ? config.link.highlightFontWeight : config.link.fontWeight;
   }
 
-  const normalizedNodeCoordinates = getNormalizedNodeCoordinates(
-    { source: { x: x1, y: y1 }, target: { x: x2, y: y2 } },
+  const { sourceCoords, targetCoords } = getNormalizedNodeCoordinates(
+    { sourceId: source, targetId: target, sourceCoords: { x: x1, y: y1 }, targetCoords: { x: x2, y: y2 } },
     nodes,
     config,
     strokeWidth
   );
-  const d = buildLinkPathDefinition(normalizedNodeCoordinates, type);
+  const d = buildLinkPathDefinition(sourceCoords, targetCoords, type);
 
   return {
     className: CONST.LINK_CLASS_NAME,

--- a/src/components/link/link.helper.js
+++ b/src/components/link/link.helper.js
@@ -61,16 +61,15 @@ function getRadiusStrategy(type) {
  * This method returns the path definition for a given link base on the line type
  * and the link source and target.
  * {@link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d|d attribute mdn}
- * @param {Object} link - the link to build the path definition
- * @param {Object} link.source - link source
- * @param {Object} link.target - link target
+ * @param {Object} sourceCoords - link sourceCoords
+ * @param {Object} targetCoords - link targetCoords
  * @param {string} type - the link line type
  * @returns {string} the path definition for the requested link
  * @memberof Link/helper
  */
-function buildLinkPathDefinition({ source = {}, target = {} }, type = LINE_TYPES.STRAIGHT) {
-  const { x: sx, y: sy } = source;
-  const { x: tx, y: ty } = target;
+function buildLinkPathDefinition(sourceCoords = {}, targetCoords = {}, type = LINE_TYPES.STRAIGHT) {
+  const { x: sx, y: sy } = sourceCoords;
+  const { x: tx, y: ty } = targetCoords;
   const validType = LINE_TYPES[type] || LINE_TYPES.STRAIGHT;
   const radius = getRadiusStrategy(validType)(sx, sy, tx, ty);
 

--- a/test/graph/graph.builder.spec.js
+++ b/test/graph/graph.builder.spec.js
@@ -28,10 +28,10 @@ describe("Graph Helper", () => {
       test("should call buildLinkPathDefinition with expected parameters", () => {
         graphHelper.buildLinkProps(that.link, {}, {}, that.config, [], undefined, undefined, 1);
 
-        expect(linkHelper.buildLinkPathDefinition).toHaveBeenCalledWith(
-          { source: { x: 0, y: 0 }, target: { x: 0, y: 0 } },
-          "STRAIGHT"
-        );
+        const sourceCoords = { x: 0, y: 0 };
+        const targetCoords = { x: 0, y: 0 };
+
+        expect(linkHelper.buildLinkPathDefinition).toHaveBeenCalledWith(sourceCoords, targetCoords, "STRAIGHT");
       });
 
       describe("and no custom color is set", () => {

--- a/test/graph/graph.helper.spec.js
+++ b/test/graph/graph.helper.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import * as graphHelper from "../../src/components/graph/graph.helper";
 
 import * as utils from "../../src/utils";
@@ -352,6 +353,238 @@ describe("Graph Helper", () => {
             );
           });
         });
+      });
+    });
+  });
+
+  describe("#getNormalizedNodeCoordinates", () => {
+    const mockInfo = {
+      sourceId: "a",
+      targetId: "b",
+      sourceCoords: {
+        x: 1,
+        y: 1,
+      },
+      targetCoords: {
+        x: 2,
+        y: 2,
+      },
+    };
+
+    it("should return same sourceCoords and targetCoords when nodes are not in the collection of nodes", () => {
+      let coords = graphHelper.getNormalizedNodeCoordinates(
+        mockInfo,
+        {
+          a: {},
+        },
+        {
+          node: {},
+        }
+      );
+
+      expect(coords).toEqual({
+        sourceCoords: { x: 1, y: 1 },
+        targetCoords: { x: 2, y: 2 },
+      });
+
+      coords = graphHelper.getNormalizedNodeCoordinates(
+        mockInfo,
+        {
+          b: {},
+        },
+        {
+          node: {},
+        }
+      );
+
+      expect(coords).toEqual({
+        sourceCoords: { x: 1, y: 1 },
+        targetCoords: { x: 2, y: 2 },
+      });
+    });
+
+    it("should return same coordinates when config or nodes have a viewGenerator", () => {
+      let coords = graphHelper.getNormalizedNodeCoordinates(
+        mockInfo,
+        {
+          a: {},
+          b: {},
+        },
+        {
+          node: {
+            viewGenerator: () => {},
+          },
+        }
+      );
+
+      expect(coords).toEqual({
+        sourceCoords: { x: 1, y: 1 },
+        targetCoords: { x: 2, y: 2 },
+      });
+
+      coords = graphHelper.getNormalizedNodeCoordinates(
+        mockInfo,
+        {
+          a: {
+            id: "a",
+            viewGenerator: () => {},
+            symbolType: "circle",
+          },
+          b: {},
+        },
+        {
+          node: {
+            symbolType: "circle",
+          },
+        }
+      );
+
+      expect(coords).toEqual({
+        sourceCoords: { x: 1, y: 1 },
+        targetCoords: { x: 2, y: 2 },
+      });
+    });
+
+    it("should return same sourceCoords and targetCoords when symbolType is something rather than CIRCLE", () => {
+      let coords = graphHelper.getNormalizedNodeCoordinates(
+        mockInfo,
+        {
+          a: {},
+          b: {},
+        },
+        {
+          node: {
+            symbolType: "square",
+          },
+        }
+      );
+
+      expect(coords).toEqual({
+        sourceCoords: { x: 1, y: 1 },
+        targetCoords: { x: 2, y: 2 },
+      });
+
+      coords = graphHelper.getNormalizedNodeCoordinates(
+        mockInfo,
+        {
+          a: {
+            symbolType: "square",
+          },
+          b: {},
+        },
+        {
+          node: {},
+        }
+      );
+
+      expect(coords).toEqual({
+        sourceCoords: { x: 1, y: 1 },
+        targetCoords: { x: 2, y: 2 },
+      });
+    });
+
+    it("should properly compute new coordinates for symbolType CIRCLE", () => {
+      let coords = graphHelper.getNormalizedNodeCoordinates(
+        mockInfo,
+        {
+          a: { size: 100 },
+          b: { size: 200 },
+        },
+        {
+          node: {
+            symbolType: "circle",
+          },
+          link: {
+            markerWith: 2,
+            markerHeight: 4,
+          },
+        }
+      );
+      const expectedCoords = {
+        sourceCoords: { x: 4.78995166381361, y: 4.78995166381361 },
+        targetCoords: { x: -3.3598010437036843, y: -3.3598010437036843 },
+      };
+
+      expect(coords).toEqual(expectedCoords);
+
+      // check for global fallback
+      coords = graphHelper.getNormalizedNodeCoordinates(
+        mockInfo,
+        {
+          a: {},
+          b: { size: 200 },
+        },
+        {
+          node: {
+            symbolType: "circle",
+            size: 100,
+          },
+          link: {
+            markerWith: 2,
+            markerHeight: 4,
+          },
+        }
+      );
+
+      expect(coords).toEqual(expectedCoords);
+    });
+
+    it("should properly compute new coordinates if given (x, y) for source and target are 0", () => {
+      // caught in: https://github.com/danielcaldas/react-d3-graph/issues/351
+      let coords = graphHelper.getNormalizedNodeCoordinates(
+        {
+          ...mockInfo,
+          targetCoords: {
+            x: 1,
+            y: 1,
+          },
+        },
+        {
+          a: { size: 100 },
+          b: { size: 200 },
+        },
+        {
+          node: {
+            symbolType: "circle",
+          },
+          link: {
+            markerWith: 2,
+            markerHeight: 4,
+          },
+        }
+      );
+
+      expect(coords).toEqual({
+        sourceCoords: { x: 1, y: 1 },
+        targetCoords: { x: 1, y: 1 },
+      });
+
+      // with config.directed: true and no link marker properties
+      coords = graphHelper.getNormalizedNodeCoordinates(
+        {
+          ...mockInfo,
+          targetCoords: {
+            x: 1,
+            y: 1,
+          },
+        },
+        {
+          a: { size: 100 },
+          b: { size: 200 },
+        },
+        {
+          directed: true,
+          node: {
+            symbolType: "circle",
+          },
+          link: {},
+        },
+        2 // strokeWidth
+      );
+
+      expect(coords).toEqual({
+        sourceCoords: { x: 1, y: 1 },
+        targetCoords: { x: 1, y: 1 },
       });
     });
   });

--- a/test/link/link.helper.spec.js
+++ b/test/link/link.helper.spec.js
@@ -3,7 +3,9 @@ import * as linkHelper from "../../src/components/link/link.helper";
 describe("Link Helper", () => {
   describe("#buildLinkPathDefinition", () => {
     test("should return expected path definition", () => {
-      const path = linkHelper.buildLinkPathDefinition({ source: { x: "1", y: "2" }, target: { x: "3", y: "4" } });
+      const sourceCoords = { x: "1", y: "2" };
+      const targetCoords = { x: "3", y: "4" };
+      const path = linkHelper.buildLinkPathDefinition(sourceCoords, targetCoords);
 
       expect(path).toEqual("M1,2A0,0 0 0,1 3,4");
     });


### PR DESCRIPTION
This PR addresses https://github.com/danielcaldas/react-d3-graph/issues/351

Some edge cases were not considered in #271, such as the possibility of coordinates values offsetting `0` triggering a division by `0`. This results in the output of this new computation being `NaN`. **The console error should disappear with this change**.

Additionally, granular support for `node.size` is added in link placement, so that the arrows don't overlap with the node when changing the `node.size` (at node level).

Here's the before & after of the behaviors.

#### Before

![before](https://user-images.githubusercontent.com/11733994/92907901-521aaa00-f458-11ea-9970-59531de24ff1.gif)


#### After

![after](https://user-images.githubusercontent.com/11733994/92907919-5646c780-f458-11ea-8518-0abf7c71bfec.gif)
