### PR TITLE
node.fontSize value now overrides config.node.fontSize value

### DIFF
--- a/src/components/graph/graph.builder.js
+++ b/src/components/graph/graph.builder.js
@@ -206,8 +206,12 @@ function buildNodeProps(node, config, nodeCallbacks = {}, highlightedNode, highl
     nodeSize.width;
   }
 
-  const fontSize = highlight ? config.node.highlightFontSize : config.node.fontSize;
-  const dx = fontSize * t + offset / 100 + 1.5;
+  const fontSize = node.fontSize || config.node.fontSize;
+  const highlightFontSize = node.highlightFontSize || config.node.highlightFontSize;
+
+  const finalFontSize = highlight ? highlightFontSize : fontSize;
+  const dx = finalFontSize * t + offset / 100 + 1.5;
+
   const svg = node.svg || config.node.svg;
   const fontColor = node.fontColor || config.node.fontColor;
 
@@ -225,7 +229,7 @@ function buildNodeProps(node, config, nodeCallbacks = {}, highlightedNode, highl
     dx,
     fill,
     fontColor,
-    fontSize: fontSize * t,
+    fontSize: finalFontSize * t,
     fontWeight: highlight ? config.node.highlightFontWeight : config.node.fontWeight,
     id: node.id,
     label,

--- a/test/graph/graph.builder.spec.js
+++ b/test/graph/graph.builder.spec.js
@@ -156,5 +156,32 @@ describe("Graph Helper", () => {
         expect(props.stroke).toEqual("yellow");
       });
     });
+    describe("and no custom fontSize is set", () => {
+      test("should return the fontSize from the config in the props", () => {
+        const props = graphHelper.buildNodeProps(
+          that.node,
+          { ...that.config, node: { ...that.config.node, fontSize: 10 } },
+          undefined,
+          undefined,
+          undefined,
+          1
+        );
+        expect(props.fontSize).toEqual(10);
+      });
+    });
+    describe("and custom fontSize is set to 6", () => {
+      test("should override the value of fontSize set in the props", () => {
+        const props = graphHelper.buildNodeProps(
+          { ...that.node, fontSize: 6 },
+          { ...that.config, node: { ...that.config.node, fontSize: 10 } },
+          undefined,
+          undefined,
+          undefined,
+          1
+        );
+
+        expect(props.fontSize).toEqual(6);
+      });
+    });
   });
 });


### PR DESCRIPTION
closes #330

This fixes the issue where individual nodes couldn't get specific `fontSize` or `highlightFontSize` values.

Here's the before & after of the behaviors.

### Before ###

![fontSizeBefore](https://user-images.githubusercontent.com/12899161/95024378-4ef79000-068b-11eb-998e-a661c7996209.png)

### After ###

![fontSizeAfter](https://user-images.githubusercontent.com/12899161/95024393-5a4abb80-068b-11eb-849f-2703aa869608.png)

