### PR TITLE
Fixing graph reset

### DIFF
--- a/src/components/graph/Graph.jsx
+++ b/src/components/graph/Graph.jsx
@@ -16,6 +16,7 @@ import {
   checkForGraphElementsChanges,
   getCenterAndZoomTransformation,
   initializeGraphState,
+  initializeNodes,
 } from "./graph.helper";
 import { renderGraph } from "./graph.renderer";
 import { merge, debounce, throwErr } from "../../utils";
@@ -478,12 +479,19 @@ export default class Graph extends React.Component {
    */
   resetNodesPositions = () => {
     if (!this.state.config.staticGraph) {
+      let initialNodesState = initializeNodes(this.props.data.nodes);
       for (let nodeId in this.state.nodes) {
         let node = this.state.nodes[nodeId];
 
         if (node.fx && node.fy) {
           Reflect.deleteProperty(node, "fx");
           Reflect.deleteProperty(node, "fy");
+        }
+
+        if (nodeId in initialNodesState) {
+          let initialNode = initialNodesState[nodeId];
+          node.x = initialNode.x;
+          node.y = initialNode.y;
         }
       }
 

--- a/src/components/graph/graph.helper.js
+++ b/src/components/graph/graph.helper.js
@@ -102,7 +102,7 @@ function _initializeLinks(graphLinks, config) {
  * and highlighted values.
  * @memberof Graph/helper
  */
-function _initializeNodes(graphNodes) {
+function initializeNodes(graphNodes) {
   let nodes = {};
   const n = graphNodes.length;
 
@@ -393,7 +393,7 @@ function initializeGraphState({ data, id, config }, state) {
 
   let newConfig = { ...merge(DEFAULT_CONFIG, config || {}) },
     links = _initializeLinks(graph.links, newConfig), // matrix of graph connections
-    nodes = _tagOrphanNodes(_initializeNodes(graph.nodes), links);
+    nodes = _tagOrphanNodes(initializeNodes(graph.nodes), links);
   const { nodes: d3Nodes, links: d3Links } = graph;
   const formatedId = id.replace(/ /g, "_");
   const simulation = _createForceSimulation(newConfig.width, newConfig.height, newConfig.d3 && newConfig.d3.gravity);
@@ -560,4 +560,5 @@ export {
   initializeGraphState,
   updateNodeHighlightedValue,
   getNormalizedNodeCoordinates,
+  initializeNodes,
 };


### PR DESCRIPTION
This should fix #372 . 

However, when the graph is reset, it now replays the force animation from the graph beginning (when you open it for the first time). 
We could maybe avoid this by checking some properties leading to a graph with forces or without (for example static graphs). We could also consider that it is normal that during a reset, the graph replays this *shrinking* animation. 

What do you think @danielcaldas ? 