### PR TITLE
Add the ability to make link cross multiple points across its route from source node to target node 

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -533,6 +533,7 @@ const graph = {
         -   "CURVE_FULL" - a semicircumference trajectory unites source and target nodes.
             </br>
             <img src="https://github.com/danielcaldas/react-d3-graph/blob/master/docs/rd3g-bend.gif?raw=true" width="820" height="480"/> (optional, default `"STRAIGHT"`)
+    -   `link.breakPoints` **[Array][185]&lt;[Object][184]>** <a id="link-type" href="#link-type">🔗</a> 🔍🔍🔍 Array of Objects that include x, y members of type `Number` (i.e. {'x': 5, 'y': 3}), which represent the additional points which the link will cross in its route from its node source to its node target. (optional, default `[]`)
 
 ### Examples
 

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -533,7 +533,6 @@ const graph = {
         -   "CURVE_FULL" - a semicircumference trajectory unites source and target nodes.
             </br>
             <img src="https://github.com/danielcaldas/react-d3-graph/blob/master/docs/rd3g-bend.gif?raw=true" width="820" height="480"/> (optional, default `"STRAIGHT"`)
-    -   `link.breakPoints` **[Array][185]&lt;[Object][184]>** <a id="link-type" href="#link-type">🔗</a> 🔍🔍🔍 Array of Objects that include x, y members of type `Number` (i.e. {'x': 5, 'y': 3}), which represent the additional points which the link will cross in its route from its node source to its node target. (optional, default `[]`)
 
 ### Examples
 

--- a/src/components/graph/graph.builder.js
+++ b/src/components/graph/graph.builder.js
@@ -127,7 +127,9 @@ function buildLinkProps(link, nodes, links, config, linkCallbacks, highlightedNo
     config,
     strokeWidth
   );
-  const d = buildLinkPathDefinition(sourceCoords, targetCoords, type);
+
+  const breakPoints = link.breakPoints || [];
+  const d = buildLinkPathDefinition(sourceCoords, targetCoords, type, breakPoints);
 
   return {
     className: CONST.LINK_CLASS_NAME,

--- a/src/components/graph/graph.builder.js
+++ b/src/components/graph/graph.builder.js
@@ -128,8 +128,7 @@ function buildLinkProps(link, nodes, links, config, linkCallbacks, highlightedNo
     strokeWidth
   );
 
-  const breakPoints = link.breakPoints || [];
-  const d = buildLinkPathDefinition(sourceCoords, targetCoords, type, breakPoints);
+  const d = buildLinkPathDefinition(sourceCoords, targetCoords, type, link.breakPoints);
 
   return {
     className: CONST.LINK_CLASS_NAME,

--- a/src/components/link/link.helper.js
+++ b/src/components/link/link.helper.js
@@ -64,16 +64,25 @@ function getRadiusStrategy(type) {
  * @param {Object} sourceCoords - link sourceCoords
  * @param {Object} targetCoords - link targetCoords
  * @param {string} type - the link line type
+ * @param {Array.<Object>} breakPoints - additional set of points that the link will cross
  * @returns {string} the path definition for the requested link
  * @memberof Link/helper
  */
-function buildLinkPathDefinition(sourceCoords = {}, targetCoords = {}, type = LINE_TYPES.STRAIGHT) {
+function buildLinkPathDefinition(sourceCoords = {}, targetCoords = {}, type = LINE_TYPES.STRAIGHT, breakPoints = []) {
   const { x: sx, y: sy } = sourceCoords;
-  const { x: tx, y: ty } = targetCoords;
   const validType = LINE_TYPES[type] || LINE_TYPES.STRAIGHT;
-  const radius = getRadiusStrategy(validType)(sx, sy, tx, ty);
 
-  return `M${sx},${sy}A${radius},${radius} 0 0,1 ${tx},${ty}`;
+  const restOfLinkPoints = [...breakPoints, targetCoords];
+  const restOfLinkPath = restOfLinkPoints
+    .map(({ x, y }, i) => {
+      const { x: px, y: py } = i > 0 ? restOfLinkPoints[i - 1] : sourceCoords;
+      const radius = getRadiusStrategy(validType)(px, py, x, y);
+
+      return ` A${radius},${radius} 0 0,1 ${x},${y}`;
+    })
+    .join("");
+
+  return `M${sx},${sy}${restOfLinkPath}`;
 }
 
 export { buildLinkPathDefinition };

--- a/src/components/link/link.helper.js
+++ b/src/components/link/link.helper.js
@@ -71,12 +71,13 @@ function getRadiusStrategy(type) {
 function buildLinkPathDefinition(sourceCoords = {}, targetCoords = {}, type = LINE_TYPES.STRAIGHT, breakPoints = []) {
   const { x: sx, y: sy } = sourceCoords;
   const validType = LINE_TYPES[type] || LINE_TYPES.STRAIGHT;
+  const calcRadiusFn = getRadiusStrategy(validType);
 
   const restOfLinkPoints = [...breakPoints, targetCoords];
   const restOfLinkPath = restOfLinkPoints
     .map(({ x, y }, i) => {
       const { x: px, y: py } = i > 0 ? restOfLinkPoints[i - 1] : sourceCoords;
-      const radius = getRadiusStrategy(validType)(px, py, x, y);
+      const radius = calcRadiusFn(px, py, x, y);
 
       return ` A${radius},${radius} 0 0,1 ${x},${y}`;
     })

--- a/test/graph/__snapshots__/graph.snapshot.spec.js.snap
+++ b/test/graph/__snapshots__/graph.snapshot.spec.js.snap
@@ -118,7 +118,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M402.6029494893985485,200-4.685309080917388A0,0 0 0,1 137.39705051060145,24.68530908091739"
+          d="M402.6029494893985485,200-4.685309080917388 A0,0 0 0,1 137.39705051060145,24.68530908091739"
           id="Harry,Sally"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -138,7 +138,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M40-1.1627040942275513,200-5.232168424023981A0,0 0 0,1 21.16270409422755,115.23216842402398"
+          d="M40-1.1627040942275513,200-5.232168424023981 A0,0 0 0,1 21.16270409422755,115.23216842402398"
           id="Harry,Mario"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -158,7 +158,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M302.3591551111937417,1844.812676426835234A0,0 0 0,1 302.64084488880627,740.1873235731648"
+          d="M302.3591551111937417,1844.812676426835234 A0,0 0 0,1 302.64084488880627,740.1873235731648"
           id="Sarah,Alice"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -178,7 +178,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M2001.230871970649426,3005.2165526375142335A0,0 0 0,1 303.76912802935055,739.7834473624857"
+          d="M2001.230871970649426,3005.2165526375142335 A0,0 0 0,1 303.76912802935055,739.7834473624857"
           id="Eveie,Alice"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -198,7 +198,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M1201.9451766013189067,2704.994372354737734A0,0 0 0,1 303.0548233986811,740.0056276452623"
+          d="M1201.9451766013189067,2704.994372354737734 A0,0 0 0,1 303.0548233986811,740.0056276452623"
           id="Peter,Alice"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -218,7 +218,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M202.194669099098748,1104.889876764658614A0,0 0 0,1 302.80533090090125,740.1101232353413"
+          d="M202.194669099098748,1104.889876764658614 A0,0 0 0,1 302.80533090090125,740.1101232353413"
           id="Mario,Alice"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -238,7 +238,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M1903.4607726849715568,6094.092739870922885A0,0 0 0,1 301.5392273150284,740.9072601290771"
+          d="M1903.4607726849715568,6094.092739870922885 A0,0 0 0,1 301.5392273150284,740.9072601290771"
           id="James,Alice"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -258,7 +258,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M405.359080979074426,2000.0878537865422037A0,0 0 0,1 95.64091902092558,200.9121462134578"
+          d="M405.359080979074426,2000.0878537865422037 A0,0 0 0,1 95.64091902092558,200.9121462134578"
           id="Harry,Carol"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -278,7 +278,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M40-5.359801043703684,2000A0,0 0 0,1 7.359801043703684,200"
+          d="M40-5.359801043703684,2000 A0,0 0 0,1 7.359801043703684,200"
           id="Harry,Nicky"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -298,7 +298,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M404-3.868474145942595,404-3.709767514314181A0,0 0 0,1 17.868474145942596,33.70976751431418"
+          d="M404-3.868474145942595,404-3.709767514314181 A0,0 0 0,1 17.868474145942596,33.70976751431418"
           id="Bobby,Frank"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -318,7 +318,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M305-2.194669099098748,745-4.889876764658614A0,0 0 0,1 22.194669099098746,114.88987676465861"
+          d="M305-2.194669099098748,745-4.889876764658614 A0,0 0 0,1 22.194669099098746,114.88987676465861"
           id="Alice,Mario"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -338,7 +338,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M40-2.472758879369286,2004.755305537248627A0,0 0 0,1 16.472758879369287,245.24469446275137"
+          d="M40-2.472758879369286,2004.755305537248627 A0,0 0 0,1 16.472758879369287,245.24469446275137"
           id="Harry,Lynne"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -358,7 +358,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M301.8884174089776617,1845.016108742596914A0,0 0 0,1 188.11158259102234,603.9838912574031"
+          d="M301.8884174089776617,1845.016108742596914 A0,0 0 0,1 188.11158259102234,603.9838912574031"
           id="Sarah,James"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -378,7 +378,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M142.4079147156322325,2594.788466764041372A0,0 0 0,1 187.59208528436776,604.2115332359587"
+          d="M142.4079147156322325,2594.788466764041372 A0,0 0 0,1 187.59208528436776,604.2115332359587"
           id="Roger,James"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -398,7 +398,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M409-4.798325813522697,5002.388207824995315A0,0 0 0,1 194.7983258135227,606.6117921750047"
+          d="M409-4.798325813522697,5002.388207824995315 A0,0 0 0,1 194.7983258135227,606.6117921750047"
           id="Maddy,James"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -418,7 +418,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M520-5.1761004847648815,1231.3912048733755413A0,0 0 0,1 19.17610048476488,257.60879512662444"
+          d="M520-5.1761004847648815,1231.3912048733755413 A0,0 0 0,1 19.17610048476488,257.60879512662444"
           id="Sonny,Roger"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -438,7 +438,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M190-2.4079147156322325,609-4.788466764041372A0,0 0 0,1 16.40791471563223,263.78846676404135"
+          d="M190-2.4079147156322325,609-4.788466764041372 A0,0 0 0,1 16.40791471563223,263.78846676404135"
           id="James,Roger"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -458,7 +458,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M305-1.9451766013189067,745-4.994372354737734A0,0 0 0,1 121.9451766013189,274.9943723547377"
+          d="M305-1.9451766013189067,745-4.994372354737734 A0,0 0 0,1 121.9451766013189,274.9943723547377"
           id="Alice,Peter"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -478,7 +478,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M142.0922556386763027,204.934565185557317A0,0 0 0,1 117.9077443613237,265.0654348144427"
+          d="M142.0922556386763027,204.934565185557317 A0,0 0 0,1 117.9077443613237,265.0654348144427"
           id="Johan,Peter"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -498,7 +498,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M305-1.230871970649426,745-5.2165526375142335A0,0 0 0,1 201.23087197064942,305.2165526375142"
+          d="M305-1.230871970649426,745-5.2165526375142335 A0,0 0 0,1 201.23087197064942,305.2165526375142"
           id="Alice,Eveie"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -518,7 +518,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M404.545102194865424,2002.8406888717908902A0,0 0 0,1 195.45489780513458,297.1593111282091"
+          d="M404.545102194865424,2002.8406888717908902 A0,0 0 0,1 195.45489780513458,297.1593111282091"
           id="Harry,Eveie"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -538,7 +538,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M200-4.545102194865424,300-2.8406888717908902A0,0 0 0,1 44.54510219486542,202.8406888717909"
+          d="M200-4.545102194865424,300-2.8406888717908902 A0,0 0 0,1 44.54510219486542,202.8406888717909"
           id="Eveie,Harry"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -558,7 +558,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M203.3134907219103313,14.212866775000279A0,0 0 0,1 86.68650927808967,85.78713322499972"
+          d="M203.3134907219103313,14.212866775000279 A0,0 0 0,1 86.68650927808967,85.78713322499972"
           id="Henry,Mikey"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -578,7 +578,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M900,656-5.359801043703684A0,0 0 0,1 90,95.35980104370368"
+          d="M900,656-5.359801043703684 A0,0 0 0,1 90,95.35980104370368"
           id="Elric,Mikey"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -598,7 +598,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M190-1.8884174089776617,609-5.016108742596914A0,0 0 0,1 31.888417408977663,189.0161087425969"
+          d="M190-1.8884174089776617,609-5.016108742596914 A0,0 0 0,1 31.888417408977663,189.0161087425969"
           id="James,Sarah"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -618,7 +618,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M305-2.3591551111937417,745-4.812676426835234A0,0 0 0,1 32.35915511119374,188.81267642683522"
+          d="M305-2.3591551111937417,745-4.812676426835234 A0,0 0 0,1 32.35915511119374,188.81267642683522"
           id="Alice,Sarah"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -638,7 +638,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M1904.798325813522697,609-2.388207824995315A0,0 0 0,1 404.2016741864773,502.38820782499533"
+          d="M1904.798325813522697,609-2.388207824995315 A0,0 0 0,1 404.2016741864773,502.38820782499533"
           id="James,Maddy"
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -658,7 +658,7 @@ exports[`Snapshot - Graph Component should match snapshot 1`] = `
       <g>
         <path
           className="link"
-          d="M120-2.0922556386763027,270-4.934565185557317A0,0 0 0,1 16.092255638676303,24.934565185557318"
+          d="M120-2.0922556386763027,270-4.934565185557317 A0,0 0 0,1 16.092255638676303,24.934565185557318"
           id="Peter,Johan"
           onClick={[Function]}
           onContextMenu={[Function]}

--- a/test/graph/graph.builder.spec.js
+++ b/test/graph/graph.builder.spec.js
@@ -31,7 +31,7 @@ describe("Graph Helper", () => {
         const sourceCoords = { x: 0, y: 0 };
         const targetCoords = { x: 0, y: 0 };
 
-        expect(linkHelper.buildLinkPathDefinition).toHaveBeenCalledWith(sourceCoords, targetCoords, "STRAIGHT");
+        expect(linkHelper.buildLinkPathDefinition).toHaveBeenCalledWith(sourceCoords, targetCoords, "STRAIGHT", []);
       });
 
       describe("and no custom color is set", () => {

--- a/test/graph/graph.builder.spec.js
+++ b/test/graph/graph.builder.spec.js
@@ -31,7 +31,12 @@ describe("Graph Helper", () => {
         const sourceCoords = { x: 0, y: 0 };
         const targetCoords = { x: 0, y: 0 };
 
-        expect(linkHelper.buildLinkPathDefinition).toHaveBeenCalledWith(sourceCoords, targetCoords, "STRAIGHT", []);
+        expect(linkHelper.buildLinkPathDefinition).toHaveBeenCalledWith(
+          sourceCoords,
+          targetCoords,
+          "STRAIGHT",
+          undefined
+        );
       });
 
       describe("and no custom color is set", () => {

--- a/test/link/link.helper.spec.js
+++ b/test/link/link.helper.spec.js
@@ -1,13 +1,50 @@
 import * as linkHelper from "../../src/components/link/link.helper";
+import { LINE_TYPES } from "../../src/components/link/link.const";
 
 describe("Link Helper", () => {
   describe("#buildLinkPathDefinition", () => {
-    test("should return expected path definition", () => {
-      const sourceCoords = { x: "1", y: "2" };
-      const targetCoords = { x: "3", y: "4" };
-      const path = linkHelper.buildLinkPathDefinition(sourceCoords, targetCoords);
+    describe("when line_type is straight", () => {
+      test("should return expected straight path definition", () => {
+        const sourceCoords = { x: 1, y: 2 };
+        const targetCoords = { x: 3, y: 4 };
+        const path = linkHelper.buildLinkPathDefinition(sourceCoords, targetCoords, LINE_TYPES.STRAIGHT);
 
-      expect(path).toEqual("M1,2A0,0 0 0,1 3,4");
+        expect(path).toEqual("M1,2 A0,0 0 0,1 3,4");
+      });
+    });
+
+    describe("when line_type is curve-smooth", () => {
+      test("should return expected curve-smooth path definition", () => {
+        const sourceCoords = { x: 1, y: 2 };
+        const targetCoords = { x: 3, y: 4 };
+        const path = linkHelper.buildLinkPathDefinition(sourceCoords, targetCoords, LINE_TYPES.CURVE_SMOOTH);
+
+        expect(path).toEqual("M1,2 A2.8284271247461903,2.8284271247461903 0 0,1 3,4");
+      });
+    });
+
+    describe("when line_type is curve-full", () => {
+      test("should return expected curve-full path definition", () => {
+        const sourceCoords = { x: 1, y: 2 };
+        const targetCoords = { x: 3, y: 4 };
+        const path = linkHelper.buildLinkPathDefinition(sourceCoords, targetCoords, LINE_TYPES.CURVE_FULL);
+
+        expect(path).toEqual("M1,2 A1,1 0 0,1 3,4");
+      });
+    });
+
+    describe("when breakPoints specified", () => {
+      test("should return expected path definition with breakPoints", () => {
+        const sourceCoords = { x: 1, y: 2 };
+        const targetCoords = { x: 3, y: 4 };
+        const breakPoints = [
+          { x: 5, y: 6 },
+          { x: 7, y: 8 },
+        ];
+        const path = linkHelper.buildLinkPathDefinition(sourceCoords, targetCoords, LINE_TYPES.STRAIGHT, breakPoints);
+
+        expect(path).toEqual("M1,2 A0,0 0 0,1 5,6 A0,0 0 0,1 7,8 A0,0 0 0,1 3,4");
+      });
     });
   });
 });


### PR DESCRIPTION
closes #373 (Even though additional functionality to the behavior mentioned in the issue may be added in the future).

This PR adds the ability to describe the Link route from its source node to target node more precise way.

The behavior can be seen in this screenshot:
![link-breakPoints](https://user-images.githubusercontent.com/12899161/95460125-359d5f00-097d-11eb-9c4a-6ab7a515de7d.png)
