### PR TITLE
Don't throw error when there are no nodes

### DIFF
--- a/src/components/graph/graph.helper.js
+++ b/src/components/graph/graph.helper.js
@@ -220,7 +220,8 @@ function _tagOrphanNodes(nodes, linksMatrix) {
  */
 function _validateGraphData(data) {
   if (!data.nodes || !data.nodes.length) {
-    throwErr("Graph", ERRORS.INSUFFICIENT_DATA);
+    logWarning("Graph", ERRORS.INSUFFICIENT_DATA);
+    data.nodes = [];
   }
 
   if (!data.links) {

--- a/test/graph/graph.helper.spec.js
+++ b/test/graph/graph.helper.spec.js
@@ -17,6 +17,7 @@ describe("Graph Helper", () => {
     utils.isEmptyObject = jest.fn();
     utils.merge = jest.fn();
     utils.throwErr = jest.fn();
+    utils.logWarning = jest.fn();
   });
 
   describe("#initializeGraphState", () => {
@@ -285,7 +286,7 @@ describe("Graph Helper", () => {
 
     describe("when invalid graph data is provided", () => {
       describe("when no nodes are provided", () => {
-        test("should throw INSUFFICIENT_DATA error", () => {
+        test("should log INSUFFICIENT_DATA warning", () => {
           const data = { nodes: [], links: [] };
 
           graphHelper.initializeGraphState(
@@ -297,7 +298,7 @@ describe("Graph Helper", () => {
             "state"
           );
 
-          expect(utils.throwErr).toHaveBeenCalledWith(
+          expect(utils.logWarning).toHaveBeenCalledWith(
             "Graph",
             "you have not provided enough data" +
               " for react-d3-graph to render something. You need to provide at least one node"

--- a/test/graph/graph.helper.spec.js
+++ b/test/graph/graph.helper.spec.js
@@ -285,19 +285,21 @@ describe("Graph Helper", () => {
     });
 
     describe("when invalid graph data is provided", () => {
-      const callInitializeGraph = data => graphHelper.initializeGraphState(
-        {
-          data,
-          id: "id",
-          config: "config",
-        },
-        "state"
-      );
+      const callInitializeGraph = data =>
+        graphHelper.initializeGraphState(
+          {
+            data,
+            id: "id",
+            config: "config",
+          },
+          "state"
+        );
 
       describe("when no data is provided", () => {
         test("should log INSUFFICIENT_DATA warning", () => {
           callInitializeGraph({});
 
+          expect(utils.throwErr).not.toHaveBeenCalled();
           expect(utils.logWarning).toHaveBeenCalledWith(
             "Graph",
             "you have not provided enough data" +
@@ -311,6 +313,7 @@ describe("Graph Helper", () => {
           const data = { nodes: [] };
           callInitializeGraph(data);
 
+          expect(utils.throwErr).not.toHaveBeenCalled();
           expect(utils.logWarning).toHaveBeenCalledWith(
             "Graph",
             "you have not provided enough data" +

--- a/test/graph/graph.helper.spec.js
+++ b/test/graph/graph.helper.spec.js
@@ -331,9 +331,8 @@ describe("Graph Helper", () => {
 
             expect(utils.throwErr).toHaveBeenCalledWith(
               "Graph",
-              "you provided a invalid links data" +
-                // eslint-disable-next-line
-                ' structure. Links source and target attributes must point to an existent node - "B" is not a valid source node id'
+              "you provided a invalid links data structure. " +
+                'Links source and target attributes must point to an existent node - "B" is not a valid source node id'
             );
           });
         });
@@ -345,9 +344,8 @@ describe("Graph Helper", () => {
 
             expect(utils.throwErr).toHaveBeenCalledWith(
               "Graph",
-              "you provided a invalid links data" +
-                // eslint-disable-next-line
-                ' structure. Links source and target attributes must point to an existent node - "B" is not a valid target node id'
+              "you provided a invalid links data structure. " +
+                'Links source and target attributes must point to an existent node - "B" is not a valid target node id'
             );
           });
         });

--- a/test/graph/graph.helper.spec.js
+++ b/test/graph/graph.helper.spec.js
@@ -335,6 +335,7 @@ describe("Graph Helper", () => {
             expect(utils.throwErr).toHaveBeenCalledWith(
               "Graph",
               "you provided a invalid links data structure. " +
+                // eslint-disable-next-line
                 'Links source and target attributes must point to an existent node - "B" is not a valid source node id'
             );
           });
@@ -348,6 +349,7 @@ describe("Graph Helper", () => {
             expect(utils.throwErr).toHaveBeenCalledWith(
               "Graph",
               "you provided a invalid links data structure. " +
+                // eslint-disable-next-line
                 'Links source and target attributes must point to an existent node - "B" is not a valid target node id'
             );
           });

--- a/test/graph/graph.helper.spec.js
+++ b/test/graph/graph.helper.spec.js
@@ -285,18 +285,31 @@ describe("Graph Helper", () => {
     });
 
     describe("when invalid graph data is provided", () => {
+      const callInitializeGraph = data => graphHelper.initializeGraphState(
+        {
+          data,
+          id: "id",
+          config: "config",
+        },
+        "state"
+      );
+
+      describe("when no data is provided", () => {
+        test("should log INSUFFICIENT_DATA warning", () => {
+          callInitializeGraph({});
+
+          expect(utils.logWarning).toHaveBeenCalledWith(
+            "Graph",
+            "you have not provided enough data" +
+              " for react-d3-graph to render something. You need to provide at least one node"
+          );
+        });
+      });
+
       describe("when no nodes are provided", () => {
         test("should log INSUFFICIENT_DATA warning", () => {
-          const data = { nodes: [], links: [] };
-
-          graphHelper.initializeGraphState(
-            {
-              data,
-              id: "id",
-              config: "config",
-            },
-            "state"
-          );
+          const data = { nodes: [] };
+          callInitializeGraph(data);
 
           expect(utils.logWarning).toHaveBeenCalledWith(
             "Graph",
@@ -314,15 +327,7 @@ describe("Graph Helper", () => {
         describe("when link source references nonexistent node", () => {
           test("should throw INVALID_LINKS error", () => {
             const data = { nodes: [{ id: "A" }], links: [{ source: "B", target: "A" }] };
-
-            graphHelper.initializeGraphState(
-              {
-                data,
-                id: "id",
-                config: "config",
-              },
-              "state"
-            );
+            callInitializeGraph(data);
 
             expect(utils.throwErr).toHaveBeenCalledWith(
               "Graph",
@@ -336,15 +341,7 @@ describe("Graph Helper", () => {
         describe("when link target references nonexistent node", () => {
           test("should throw INVALID_LINKS error", () => {
             const data = { nodes: [{ id: "A" }], links: [{ source: "A", target: "B" }] };
-
-            graphHelper.initializeGraphState(
-              {
-                data,
-                id: "id",
-                config: "config",
-              },
-              "state"
-            );
+            callInitializeGraph(data);
 
             expect(utils.throwErr).toHaveBeenCalledWith(
               "Graph",


### PR DESCRIPTION
This PR updates the process of graph data validation so that including at least a node is no longer mandatory. 

If the user forgets to pass at least a node (or sets an empty node array in purpose) to the `Graph` component, they will not get an exception. Instead, a warning message will be displayed on console just to make them aware that they haven't added any node, in case they're not aware of it. 

Tests have been updated to check this new logic.

Should resolve #347.