### PR TITLE
Adding a parameter to allow graphs to be bounded

### DIFF
--- a/src/components/graph/Graph.jsx
+++ b/src/components/graph/Graph.jsx
@@ -17,6 +17,7 @@ import {
   getCenterAndZoomTransformation,
   initializeGraphState,
   initializeNodes,
+  isPositionInBounds,
 } from "./graph.helper";
 import { renderGraph } from "./graph.renderer";
 import { merge, debounce, throwErr } from "../../utils";
@@ -235,16 +236,9 @@ export default class Graph extends React.Component {
       draggedNode.oldX = draggedNode.x;
       draggedNode.oldY = draggedNode.y;
 
-      const { transform, config } = this.state;
       const newX = draggedNode.x + d3Event.dx;
       const newY = draggedNode.y + d3Event.dy;
-      const invertTransformZoom = 1 / transform.k;
-      const shouldUpdateNode =
-        !config.bounded ||
-        (newX > -transform.x * invertTransformZoom &&
-          newX < (config.width - transform.x) * invertTransformZoom &&
-          newY > -transform.y * invertTransformZoom &&
-          newY < (config.height - transform.y) * invertTransformZoom);
+      const shouldUpdateNode = !this.state.config.bounded || isPositionInBounds({ x: newX, y: newY }, this.state);
 
       if (shouldUpdateNode) {
         draggedNode.x = newX;

--- a/src/components/graph/Graph.jsx
+++ b/src/components/graph/Graph.jsx
@@ -317,7 +317,7 @@ export default class Graph extends React.Component {
 
     d3SelectAll(`#${this.state.id}-${CONST.GRAPH_CONTAINER_ID}`).attr("transform", transform);
 
-    this.setState({ transform: transform });
+    this.setState({ transform });
 
     // only send zoom change events if the zoom has changed (_zoomed() also gets called when panning)
     if (this.debouncedOnZoomChange && this.state.previousZoom !== transform.k && !this.state.config.panAndZoom) {

--- a/src/components/graph/graph.config.js
+++ b/src/components/graph/graph.config.js
@@ -90,6 +90,8 @@
  * @param {boolean} [staticGraphWithDragAndDrop] - <a id="static-graph-with-drag-and-drop" href="#static-graph-with-drag-and-drop">🔗</a> exactly the same as above <code>staticGraph</code>, but it will allow users to drag&drop nodes.
  * <b>Note</b>: If <code>staticGraph</code> is set to <code>true</code>, then <code>staticGraphWithDragAndDrop</code> will not produce the desired behaviour, make sure
  * to set only one of them to <code>true</code>.
+ * @param {boolean} [bounded=false] - <a id="bounded" href="#bounded">🔗</a> if the graph is set as bounded, it will be impossible
+ * to drag nodes outside the viewport. It does not apply to moving the entire graph around or when zooming in or out.
  * @param {number} [width=800] - <a id="width" href="#width">🔗</a> the width of the (svg) area where the graph will be rendered.
  * </br>
  * @param {Object} d3 d3 object is explained in next section. ⬇️
@@ -256,6 +258,7 @@ export default {
   panAndZoom: false,
   staticGraph: false,
   staticGraphWithDragAndDrop: false,
+  bounded: false,
   width: 800,
   d3: {
     alphaTarget: 0.05,

--- a/src/components/graph/graph.helper.js
+++ b/src/components/graph/graph.helper.js
@@ -553,6 +553,23 @@ function getNormalizedNodeCoordinates(
   return { sourceCoords: { x: x1, y: y1 }, targetCoords: { x: x2, y: y2 } };
 }
 
+/**
+ * Checks if the position is inside the viewport bounds
+ * @param {{x: number, y: number}} position node's position
+ * @param {Object} currentState - the current state of the graph.
+ * @returns {boolean} true if the position is inside the viewport else false
+ */
+function isPositionInBounds(position, currentState) {
+  const { transform, config } = currentState;
+  const invertTransformZoom = 1 / transform.k;
+  return (
+    position.x > -transform.x * invertTransformZoom &&
+    position.x < (config.width - transform.x) * invertTransformZoom &&
+    position.y > -transform.y * invertTransformZoom &&
+    position.y < (config.height - transform.y) * invertTransformZoom
+  );
+}
+
 export {
   checkForGraphConfigChanges,
   checkForGraphElementsChanges,
@@ -562,4 +579,5 @@ export {
   updateNodeHighlightedValue,
   getNormalizedNodeCoordinates,
   initializeNodes,
+  isPositionInBounds,
 };

--- a/src/components/graph/graph.helper.js
+++ b/src/components/graph/graph.helper.js
@@ -417,7 +417,7 @@ function initializeGraphState({ data, id, config }, state) {
     simulation,
     newGraphElements: false,
     configUpdated: false,
-    transform: 1,
+    transform: { x: 0, y: 0, k: 1 },
     draggedNode: null,
   };
 }

--- a/test/graph/graph.helper.spec.js
+++ b/test/graph/graph.helper.spec.js
@@ -278,7 +278,7 @@ describe("Graph Helper", () => {
           simulation: {
             force: forceStub,
           },
-          transform: 1,
+          transform: { x: 0, y: 0, k: 1 },
           draggedNode: null,
         });
       });


### PR DESCRIPTION
Implementing feature request #285 

This does not have an effect when zooming or even moving the graph around, only when moving nodes. 
A complete version could be implemented to keep the entire graph in the viewport but in my opinion, it would be very annoying when trying to zoom on a graph with a lot of elements since it would prevent the graph to be zoomed at some point. 

⚠️ This Pull Request does not implement the boundary restriction when creating nodes. 