### PR TITLE
Render self links

### DIFF
--- a/sandbox/data/small/small.data.js
+++ b/sandbox/data/small/small.data.js
@@ -2,6 +2,11 @@ module.exports = {
   links: [
     {
       source: 1,
+      target: 2,
+      label: "link 1 and 2",
+    },
+    {
+      source: 1,
       target: 3,
     },
     {
@@ -10,11 +15,14 @@ module.exports = {
     },
     {
       source: 3,
-      target: 3,
-      selfLinkDirection: "BOTTOM_LEFT",
+      target: 4,
+      breakPoints: [
+        { x: 100, y: 20 },
+        { x: 20, y: 100 },
+      ],
     },
     {
-      source: 3,
+      source: 4,
       target: 4,
     },
   ],

--- a/src/components/graph/graph.builder.js
+++ b/src/components/graph/graph.builder.js
@@ -128,7 +128,7 @@ function buildLinkProps(link, nodes, links, config, linkCallbacks, highlightedNo
     strokeWidth
   );
 
-  const d = buildLinkPathDefinition(sourceCoords, targetCoords, type, link.breakPoints);
+  const d = buildLinkPathDefinition(sourceCoords, targetCoords, type, link.breakPoints, link.source, link.target);
 
   return {
     className: CONST.LINK_CLASS_NAME,

--- a/src/components/graph/graph.builder.js
+++ b/src/components/graph/graph.builder.js
@@ -60,6 +60,7 @@ function buildLinkProps(link, nodes, links, config, linkCallbacks, highlightedNo
   let y2 = nodes?.[target]?.y || 0;
 
   const type = link.type || config.link.type;
+  const selfLinkDirection = link.selfLinkDirection || config.link.selfLinkDirection;
 
   let mainNodeParticipates = false;
 
@@ -128,7 +129,15 @@ function buildLinkProps(link, nodes, links, config, linkCallbacks, highlightedNo
     strokeWidth
   );
 
-  const d = buildLinkPathDefinition(sourceCoords, targetCoords, type, link.breakPoints, link.source, link.target);
+  const d = buildLinkPathDefinition(
+    sourceCoords,
+    targetCoords,
+    type,
+    link.breakPoints,
+    link.source,
+    link.target,
+    selfLinkDirection
+  );
 
   return {
     className: CONST.LINK_CLASS_NAME,

--- a/src/components/graph/graph.config.js
+++ b/src/components/graph/graph.config.js
@@ -319,5 +319,6 @@ export default {
     markerHeight: 6,
     markerWidth: 6,
     type: "STRAIGHT",
+    selfLinkDirection: "TOP_RIGHT",
   },
 };

--- a/src/components/link/link.const.js
+++ b/src/components/link/link.const.js
@@ -16,4 +16,19 @@ const LINE_TYPES = {
   CURVE_FULL: "CURVE_FULL",
 };
 
-export { LINE_TYPES };
+/**
+ * @typedef {Object} SELF_LINK_DIRECTION
+ * @property {string} TOP_LEFT - a self link will be drawn at the top left of a node.
+ * @property {string} TOP_RIGHT - a self link will be drawn at the top right of a node.
+ * @property {string} BOTTOM_LEFT - a self link will be drawn at the bottom left of a node.
+ * @property {string} BOTTOM_RIGHT - a self link will be drawn at the bottom right of a node.
+ * @memberof Link/const
+ */
+const SELF_LINK_DIRECTION = {
+  TOP_LEFT: "TOP_LEFT",
+  TOP_RIGHT: "TOP_RIGHT",
+  BOTTOM_LEFT: "BOTTOM_LEFT",
+  BOTTOM_RIGHT: "BOTTOM_RIGHT",
+};
+
+export { LINE_TYPES, SELF_LINK_DIRECTION };

--- a/src/components/link/link.helper.js
+++ b/src/components/link/link.helper.js
@@ -65,13 +65,22 @@ function getRadiusStrategy(type) {
  * @param {Object} targetCoords - link targetCoords
  * @param {string} type - the link line type
  * @param {Array.<Object>} breakPoints - additional set of points that the link will cross
+ * @param {string|number} sourceId - the source node id
+ * @param {string|number} targetId - the target node id
  * @returns {string} the path definition for the requested link
  * @memberof Link/helper
  */
-function buildLinkPathDefinition(sourceCoords = {}, targetCoords = {}, type = LINE_TYPES.STRAIGHT, breakPoints = []) {
+function buildLinkPathDefinition(
+  sourceCoords = {},
+  targetCoords = {},
+  type = LINE_TYPES.STRAIGHT,
+  breakPoints = [],
+  sourceId,
+  targetId
+) {
   const { x: sx, y: sy } = sourceCoords;
   const { x: tx, y: ty } = targetCoords;
-  if (sx === tx && sy === ty) return `M${sx},${sy} A40,30 -45 1,1 ${tx + 1},${ty + 1}`;
+  if (sourceId === targetId && sx === tx && sy === ty) return `M${sx},${sy} A40,30 -45 1,1 ${tx + 1},${ty + 1}`;
   const validType = LINE_TYPES[type] || LINE_TYPES.STRAIGHT;
   const calcRadiusFn = getRadiusStrategy(validType);
 

--- a/src/components/link/link.helper.js
+++ b/src/components/link/link.helper.js
@@ -3,7 +3,7 @@
  * @description
  * A set of helper methods to manipulate/create links.
  */
-import { LINE_TYPES } from "./link.const";
+import { LINE_TYPES, SELF_LINK_DIRECTION } from "./link.const";
 
 /**
  * Computes radius value for a straight line.
@@ -67,6 +67,7 @@ function getRadiusStrategy(type) {
  * @param {Array.<Object>} breakPoints - additional set of points that the link will cross
  * @param {string|number} sourceId - the source node id
  * @param {string|number} targetId - the target node id
+ * @param {string} selfLinkDirection - the direction that self links will be rendered in
  * @returns {string} the path definition for the requested link
  * @memberof Link/helper
  */
@@ -76,11 +77,23 @@ function buildLinkPathDefinition(
   type = LINE_TYPES.STRAIGHT,
   breakPoints = [],
   sourceId,
-  targetId
+  targetId,
+  selfLinkDirection = SELF_LINK_DIRECTION.TOP_RIGHT
 ) {
   const { x: sx, y: sy } = sourceCoords;
   const { x: tx, y: ty } = targetCoords;
-  if (sourceId === targetId && sx === tx && sy === ty) return `M${sx},${sy} A40,30 -45 1,1 ${tx + 1},${ty + 1}`;
+  if (sourceId === targetId && sx === tx && sy === ty) {
+    switch (selfLinkDirection) {
+      case SELF_LINK_DIRECTION.TOP_LEFT:
+        return `M${sx},${sy} A40,30 45 1,1 ${tx + 1},${ty - 1}`;
+      case SELF_LINK_DIRECTION.BOTTOM_LEFT:
+        return `M${sx},${sy} A40,30 -45 1,1 ${tx - 1},${ty - 1}`;
+      case SELF_LINK_DIRECTION.BOTTOM_RIGHT:
+        return `M${sx},${sy} A40,30 45 1,1 ${tx - 1},${ty + 1}`;
+      default:
+        return `M${sx},${sy} A40,30 -45 1,1 ${tx + 1},${ty + 1}`;
+    }
+  }
   const validType = LINE_TYPES[type] || LINE_TYPES.STRAIGHT;
   const calcRadiusFn = getRadiusStrategy(validType);
 

--- a/src/components/link/link.helper.js
+++ b/src/components/link/link.helper.js
@@ -70,6 +70,8 @@ function getRadiusStrategy(type) {
  */
 function buildLinkPathDefinition(sourceCoords = {}, targetCoords = {}, type = LINE_TYPES.STRAIGHT, breakPoints = []) {
   const { x: sx, y: sy } = sourceCoords;
+  const { x: tx, y: ty } = targetCoords;
+  if (sx === tx && sy === ty) return `M${sx},${sy} A40,30 -45 1,1 ${tx + 1},${ty + 1}`;
   const validType = LINE_TYPES[type] || LINE_TYPES.STRAIGHT;
   const calcRadiusFn = getRadiusStrategy(validType);
 

--- a/test/graph/graph.builder.spec.js
+++ b/test/graph/graph.builder.spec.js
@@ -35,7 +35,10 @@ describe("Graph Helper", () => {
           sourceCoords,
           targetCoords,
           "STRAIGHT",
-          undefined
+          undefined,
+          that.link.source,
+          that.link.target,
+          "TOP_RIGHT"
         );
       });
 


### PR DESCRIPTION
Implements the feature outlined in #391 

So this code will render a self link if the source and target nodes have the same x and y values. This means that this would also apply to 2 separate nodes if they had the same x and y values. I could pass in the source and target id's to make sure that we are only rendering these links for actual self links, however I think leaving it as is could also be beneficial. 

If, for example, two nodes are so close together that you cannot see the link between them, then maybe rendering one of these "self links" would be useful to help visualize that these two nodes are connected.

![output](https://user-images.githubusercontent.com/23760949/99581536-cc563600-2995-11eb-968c-a59fd94a627e.gif)

Let me know your thoughts and I can make further changes as you see fit.


