### PR TITLE
Adding links to codesandbox examples in the sandbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10688,6 +10688,12 @@
         "yallist": "^3.0.2"
       }
     },
+    "lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "dev": true
+    },
     "make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "jest": "24.9.0",
     "jsdoc": "^3.6.3",
     "lint-staged": "9.2.5",
+    "lz-string": "^1.4.4",
     "npm-run-all": "4.1.5",
     "prettier": "1.19.1",
     "query-string": "6.8.3",

--- a/sandbox/Sandbox.jsx
+++ b/sandbox/Sandbox.jsx
@@ -9,6 +9,7 @@ import defaultConfig from "../src/components/graph/graph.config";
 import { Graph } from "../src";
 import { generateFormSchema, loadDataset, setValue, tooltipReducer } from "./utils";
 import { isDeepEqual, merge } from "../src/utils";
+import { createCodeSandbox } from "./createCodeSandbox";
 
 import "react-toastify/dist/ReactToastify.css";
 import "./styles.css";
@@ -369,12 +370,12 @@ export default class Sandbox extends React.Component {
           <b>Nodes: </b> {this.state.data.nodes.length} |<b>Links: </b> {this.state.data.links.length} |<b>Zoom: </b>{" "}
           {this.state.currentZoom ? this.state.currentZoom.toFixed(3) : "-"}
         </span>
-        <a
-          className="container__graph-info"
-          href="https://codesandbox.io/s/react-d3-graph-small-c4y1v?fontsize=14&hidenavigation=1&theme=dark"
-        >
-          <img alt="Edit react-d3-graph-small" src="https://codesandbox.io/static/img/play-codesandbox.svg" />
-        </a>
+        <img
+          width="150px"
+          alt="Edit react-d3-graph"
+          src="https://codesandbox.io/static/img/play-codesandbox.svg"
+          onClick={() => createCodeSandbox(this.state.config, this.state.data)}
+        />
       </div>
     );
   };

--- a/sandbox/Sandbox.jsx
+++ b/sandbox/Sandbox.jsx
@@ -9,7 +9,7 @@ import defaultConfig from "../src/components/graph/graph.config";
 import { Graph } from "../src";
 import { generateFormSchema, loadDataset, setValue, tooltipReducer } from "./utils";
 import { isDeepEqual, merge } from "../src/utils";
-import { createCodeSandbox } from "./createCodeSandbox";
+import { createCodeSandbox, deactivateCodeSandboxLink } from "./createCodeSandbox";
 
 import "react-toastify/dist/ReactToastify.css";
 import "./styles.css";
@@ -370,12 +370,16 @@ export default class Sandbox extends React.Component {
           <b>Nodes: </b> {this.state.data.nodes.length} |<b>Links: </b> {this.state.data.links.length} |<b>Zoom: </b>{" "}
           {this.state.currentZoom ? this.state.currentZoom.toFixed(3) : "-"}
         </span>
-        <img
-          width="150px"
-          alt="Edit react-d3-graph"
-          src="https://codesandbox.io/static/img/play-codesandbox.svg"
-          onClick={() => createCodeSandbox(this.state.config, this.state.data)}
-        />
+        {!deactivateCodeSandboxLink(this.state.config) && (
+          <a href="javascript:void(0)">
+            <img
+              width="150px"
+              alt="Edit react-d3-graph"
+              src="https://codesandbox.io/static/img/play-codesandbox.svg"
+              onClick={() => createCodeSandbox(this.state.config, this.state.data)}
+            />
+          </a>
+        )}
       </div>
     );
   };

--- a/sandbox/Sandbox.jsx
+++ b/sandbox/Sandbox.jsx
@@ -1,4 +1,4 @@
-/*eslint require-jsdoc: 0, valid-jsdoc: 0, no-console: 0*/
+/*eslint require-jsdoc: 0, valid-jsdoc: 0, no-console: 0, max-lines: 0*/
 import React from "react";
 import { JsonTree } from "react-editable-json-tree";
 import Form from "react-jsonschema-form";

--- a/sandbox/Sandbox.jsx
+++ b/sandbox/Sandbox.jsx
@@ -369,6 +369,12 @@ export default class Sandbox extends React.Component {
           <b>Nodes: </b> {this.state.data.nodes.length} |<b>Links: </b> {this.state.data.links.length} |<b>Zoom: </b>{" "}
           {this.state.currentZoom ? this.state.currentZoom.toFixed(3) : "-"}
         </span>
+        <a
+          className="container__graph-info"
+          href="https://codesandbox.io/s/react-d3-graph-small-c4y1v?fontsize=14&hidenavigation=1&theme=dark"
+        >
+          <img alt="Edit react-d3-graph-small" src="https://codesandbox.io/static/img/play-codesandbox.svg" />
+        </a>
       </div>
     );
   };

--- a/sandbox/createCodeSandbox.js
+++ b/sandbox/createCodeSandbox.js
@@ -49,22 +49,6 @@ function formatFile(json) {
 }
 
 /**
- * Remove the viewGenerator as it is not supported for now
- */
-function formatConfig(config) {
-  if (!config.node?.viewGenerator) {
-    return config;
-  }
-  return {
-    ...config,
-    node: {
-      ...config.node,
-      viewGenerator: undefined,
-    },
-  };
-}
-
-/**
  * Create and send the code sandbox from the current sandbox data
  * @param {*} config current sandbox config
  * @param {*} data current sandbox data
@@ -84,7 +68,7 @@ export function createCodeSandbox(config, data) {
         },
       },
       "index.js": { content: getIndexFile() },
-      "config.js": { content: formatFile(formatConfig(config)) },
+      "config.js": { content: formatFile(config) },
       "data.js": { content: formatFile(data) },
     },
   });
@@ -97,4 +81,13 @@ export function createCodeSandbox(config, data) {
   document.body.appendChild(form);
   form.submit();
   document.body.removeChild(form);
+}
+
+/**
+ * We deactivate code sandboxes link generation for sandboxes that
+ * have a view generator
+ * See : https://github.com/danielcaldas/react-d3-graph/pull/417#issuecomment-763051874
+ */
+export function deactivateCodeSandboxLink(config) {
+  return config.node?.viewGenerator;
 }

--- a/sandbox/createCodeSandbox.js
+++ b/sandbox/createCodeSandbox.js
@@ -1,5 +1,12 @@
+/*eslint require-jsdoc: 0, valid-jsdoc: 0*/
+
 import LZString from "lz-string";
 
+/**
+ * Compressing an object into a sendable string
+ *
+ * @param {Object} object object to compress
+ */
 function compress(object) {
   return LZString.compressToBase64(JSON.stringify(object))
     .replace(/\+/g, "-") // Convert '+' to '-'
@@ -7,6 +14,9 @@ function compress(object) {
     .replace(/=+$/, ""); // Remove ending '='
 }
 
+/**
+ * Creating an hidden input to send the codesandbox
+ */
 function addHiddenInput(form, name, value) {
   const input = document.createElement("input");
   input.type = "hidden";
@@ -15,6 +25,9 @@ function addHiddenInput(form, name, value) {
   form.appendChild(input);
 }
 
+/**
+ * Content of the index.js file
+ */
 function getIndexFile() {
   return `import React from "react";
 import ReactDOM from "react-dom";
@@ -27,11 +40,17 @@ const rootElement = document.getElementById("root");
 ReactDOM.render(<Graph id="graph" config={config} data={data} />, rootElement);`.trim();
 }
 
+/**
+ * Formatting file into a sendable string
+ * @param {*} json object to send
+ */
 function formatFile(json) {
   return `module.exports = ${JSON.stringify(json)}`;
 }
 
-// Remove the viewGenerator as it is not supported for now
+/**
+ * Remove the viewGenerator as it is not supported for now
+ */
 function formatConfig(config) {
   if (!config.node?.viewGenerator) {
     return config;
@@ -45,6 +64,11 @@ function formatConfig(config) {
   };
 }
 
+/**
+ * Create and send the code sandbox from the current sandbox data
+ * @param {*} config current sandbox config
+ * @param {*} data current sandbox data
+ */
 export function createCodeSandbox(config, data) {
   const parameters = compress({
     files: {

--- a/sandbox/createCodeSandbox.js
+++ b/sandbox/createCodeSandbox.js
@@ -1,0 +1,76 @@
+import LZString from "lz-string";
+
+function compress(object) {
+  return LZString.compressToBase64(JSON.stringify(object))
+    .replace(/\+/g, "-") // Convert '+' to '-'
+    .replace(/\//g, "_") // Convert '/' to '_'
+    .replace(/=+$/, ""); // Remove ending '='
+}
+
+function addHiddenInput(form, name, value) {
+  const input = document.createElement("input");
+  input.type = "hidden";
+  input.name = name;
+  input.value = value;
+  form.appendChild(input);
+}
+
+function getIndexFile() {
+  return `import React from "react";
+import ReactDOM from "react-dom";
+import { Graph } from "react-d3-graph";
+
+import config from "./config";
+import data from "./data";
+
+const rootElement = document.getElementById("root");
+ReactDOM.render(<Graph id="graph" config={config} data={data} />, rootElement);`.trim();
+}
+
+function formatFile(json) {
+  return `module.exports = ${JSON.stringify(json)}`;
+}
+
+// Remove the viewGenerator as it is not supported for now
+function formatConfig(config) {
+  if (!config.node?.viewGenerator) {
+    return config;
+  }
+  return {
+    ...config,
+    node: {
+      ...config.node,
+      viewGenerator: undefined,
+    },
+  };
+}
+
+export function createCodeSandbox(config, data) {
+  const parameters = compress({
+    files: {
+      "package.json": {
+        content: {
+          title: "react-d3-graph demo",
+          dependencies: {
+            "react-dom": "latest",
+            react: "latest",
+            "react-d3-graph": "latest",
+            d3: "5.5.0",
+          },
+        },
+      },
+      "index.js": { content: getIndexFile() },
+      "config.js": { content: formatFile(formatConfig(config)) },
+      "data.js": { content: formatFile(data) },
+    },
+  });
+
+  const form = document.createElement("form");
+  form.method = "POST";
+  form.target = "_blank";
+  form.action = "https://codeSandbox.io/api/v1/sandboxes/define";
+  addHiddenInput(form, "parameters", parameters);
+  document.body.appendChild(form);
+  form.submit();
+  document.body.removeChild(form);
+}


### PR DESCRIPTION
I think that it will easier to try the package or even to make reproductions for issues by providing an environment to test code with react-d3-graph. 

I think that [codesandbox](https://codesandbox.io/) is a really good candidate for this. And we could provide a minimal reproduction of each of the react-d3-graph sandbox examples in a separate sandbox, and add a button to go to codesandbox. 

I currently created a minimal reproduction of the small data example [here](https://codesandbox.io/s/react-d3-graph-small-c4y1v). 

And here it is how it looks with a link in the react-d3-graph sandbox : 
![sandbox](https://user-images.githubusercontent.com/26838971/103030663-8d02a280-455c-11eb-9f18-973622db4506.PNG)

What do you think about this? 