### PR TITLE
Fixing initial nodes positioning not using forces update

### DIFF
--- a/sandbox/Sandbox.jsx
+++ b/sandbox/Sandbox.jsx
@@ -257,22 +257,6 @@ export default class Sandbox extends React.Component {
   };
 
   /**
-   * This function decorates nodes and links with positions. The motivation
-   * for this function its to set `config.staticGraph` to true on the first render
-   * call, and to get nodes and links statically set to their initial positions.
-   * @param  {Object} nodes nodes and links with minimalist structure.
-   * @return {Object} the graph where now nodes containing (x,y) coords.
-   */
-  decorateGraphNodesWithInitialPositioning = nodes => {
-    return nodes.map(n =>
-      Object.assign({}, n, {
-        x: n.x || Math.floor(Math.random() * 500),
-        y: n.y || Math.floor(Math.random() * 500),
-      })
-    );
-  };
-
-  /**
    * Before removing elements (nodes, links)
    * from the graph data, this function is executed.
    * https://github.com/oxyno-zeta/react-editable-json-tree#beforeremoveaction
@@ -409,7 +393,7 @@ export default class Sandbox extends React.Component {
     // This does not happens in this sandbox scenario running time, but if we set staticGraph config
     // to true in the constructor we will provide nodes with initial positions
     const data = {
-      nodes: this.decorateGraphNodesWithInitialPositioning(this.state.data.nodes),
+      nodes: this.state.data.nodes,
       links: this.state.data.links,
       focusedNodeId: this.state.data.focusedNodeId,
     };

--- a/src/components/graph/Graph.jsx
+++ b/src/components/graph/Graph.jsx
@@ -192,7 +192,14 @@ export default class Graph extends React.Component {
    */
   _graphBindD3ToReactComponent() {
     if (!this.state.config.d3.disableLinkForce) {
-      this.state.simulation.nodes(this.state.d3Nodes).on("tick", this._tick);
+      this.state.simulation.nodes(this.state.d3Nodes).on("tick", () => {
+        // Propagate d3Nodes changes to nodes
+        const newNodes = {};
+        for (const node of this.state.d3Nodes) {
+          newNodes[node.id] = node;
+        }
+        this._tick({ d3Nodes: this.state.d3Nodes, nodes: newNodes });
+      });
       this._graphLinkForceConfig();
     }
     if (!this.state.config.freezeAllDragEvents) {


### PR DESCRIPTION
This should fix the d3 force not being properly propagated. 
Related issues : #440, #448

Also removed the code generating random position in the sandbox that could be misleading for reproductions. 

⚠️ `d3Nodes` and `nodes` varariables seem duplicated (one is a list, the other is a dictionary) and maybe should be merged? 

Before change:

![before](https://user-images.githubusercontent.com/26838971/112756460-911fdf80-8fe5-11eb-9c55-781c7c14a68b.PNG)

After change:

![after](https://user-images.githubusercontent.com/26838971/112756468-97ae5700-8fe5-11eb-8858-fd15e5f357da.PNG)
