### PR TITLE
Fixing onDoubleClickNode handler never being called when nodes are collapsible

### DIFF
--- a/src/components/graph/Graph.jsx
+++ b/src/components/graph/Graph.jsx
@@ -358,44 +358,43 @@ export default class Graph extends React.Component {
    */
   onClickNode = clickedNodeId => {
     const clickedNode = this.state.nodes[clickedNodeId];
+    if (!this.nodeClickTimer) {
+      this.nodeClickTimer = setTimeout(() => {
+        if (this.state.config.collapsible) {
+          const leafConnections = getTargetLeafConnections(clickedNodeId, this.state.links, this.state.config);
+          const links = toggleLinksMatrixConnections(this.state.links, leafConnections, this.state.config);
+          const d3Links = toggleLinksConnections(this.state.d3Links, links);
+          const firstLeaf = leafConnections?.["0"];
 
-    if (this.state.config.collapsible) {
-      const leafConnections = getTargetLeafConnections(clickedNodeId, this.state.links, this.state.config);
-      const links = toggleLinksMatrixConnections(this.state.links, leafConnections, this.state.config);
-      const d3Links = toggleLinksConnections(this.state.d3Links, links);
-      const firstLeaf = leafConnections?.["0"];
+          let isExpanding = false;
 
-      let isExpanding = false;
+          if (firstLeaf) {
+            const visibility = links[firstLeaf.source][firstLeaf.target];
 
-      if (firstLeaf) {
-        const visibility = links[firstLeaf.source][firstLeaf.target];
-
-        isExpanding = visibility === 1;
-      }
-
-      this._tick(
-        {
-          links,
-          d3Links,
-        },
-        () => {
-          this.props.onClickNode && this.props.onClickNode(clickedNodeId, clickedNode);
-
-          if (isExpanding) {
-            this._graphNodeDragConfig();
+            isExpanding = visibility === 1;
           }
-        }
-      );
-    } else {
-      if (!this.nodeClickTimer) {
-        this.nodeClickTimer = setTimeout(() => {
+
+          this._tick(
+            {
+              links,
+              d3Links,
+            },
+            () => {
+              this.props.onClickNode && this.props.onClickNode(clickedNodeId, clickedNode);
+
+              if (isExpanding) {
+                this._graphNodeDragConfig();
+              }
+            }
+          );
+        } else {
           this.props.onClickNode && this.props.onClickNode(clickedNodeId, clickedNode);
-          this.nodeClickTimer = null;
-        }, CONST.TTL_DOUBLE_CLICK_IN_MS);
-      } else {
-        this.props.onDoubleClickNode && this.props.onDoubleClickNode(clickedNodeId, clickedNode);
-        this.nodeClickTimer = clearTimeout(this.nodeClickTimer);
-      }
+        }
+        this.nodeClickTimer = null;
+      }, CONST.TTL_DOUBLE_CLICK_IN_MS);
+    } else {
+      this.props.onDoubleClickNode && this.props.onDoubleClickNode(clickedNodeId, clickedNode);
+      this.nodeClickTimer = clearTimeout(this.nodeClickTimer);
     }
   };
 


### PR DESCRIPTION
This is a simple fix for the issue described in #294. Double clicks are now possible on collapsible graphs, instead of the single click handler being called twice.