### PR TITLE
bug fix: Link label not properly centering

### DIFF
--- a/src/components/link/Link.jsx
+++ b/src/components/link/Link.jsx
@@ -99,6 +99,7 @@ export default class Link extends React.Component {
         fill: this.props.fontColor,
         fontSize: this.props.fontSize,
         fontWeight: this.props.fontWeight,
+        textAnchor: "middle",
       },
     };
 
@@ -106,7 +107,7 @@ export default class Link extends React.Component {
       <g>
         <path {...lineProps} id={id} />
         {label && (
-          <text style={{ textAnchor: "middle" }} {...textProps}>
+          <text {...textProps}>
             <textPath href={`#${id}`} startOffset="50%">
               {label}
             </textPath>


### PR DESCRIPTION
Resolves #420

Happened to run into the issue myself while working on a program that relies heavily on link labelling and stumbled across the open issue and figured I'd handle it since I needed the fix. Version still needs to be bumped, I imagine to 2.6.1 but let me know if 2.7 would be preferable for any reason and I'll take care of it