### PR TITLE
Bug Fix: Hide nodes marked as orphans when rendering collapsible graph

### DIFF
--- a/src/components/graph/Graph.jsx
+++ b/src/components/graph/Graph.jsx
@@ -18,6 +18,7 @@ import {
   initializeGraphState,
   initializeNodes,
   isPositionInBounds,
+  _tagOrphanNodes,
 } from "./graph.helper";
 import { renderGraph } from "./graph.renderer";
 import { merge, debounce, throwErr } from "../../utils";
@@ -658,7 +659,7 @@ export default class Graph extends React.Component {
 
   render() {
     const { nodes, links, defs } = renderGraph(
-      this.state.nodes,
+      _tagOrphanNodes(this.state.nodes, this.state.links),
       {
         onClickNode: this.onClickNode,
         onDoubleClickNode: this.onDoubleClickNode,

--- a/src/components/graph/collapse.helper.js
+++ b/src/components/graph/collapse.helper.js
@@ -139,7 +139,7 @@ function isNodeVisible(nodeId, nodes, linksMatrix) {
     return false;
   }
   if (nodes[nodeId]._orphan) {
-    return false;
+    return true;
   }
 
   const { inDegree, outDegree } = computeNodeDegree(nodeId, linksMatrix);

--- a/src/components/graph/collapse.helper.js
+++ b/src/components/graph/collapse.helper.js
@@ -139,7 +139,7 @@ function isNodeVisible(nodeId, nodes, linksMatrix) {
     return false;
   }
   if (nodes[nodeId]._orphan) {
-    return true;
+    return false;
   }
 
   const { inDegree, outDegree } = computeNodeDegree(nodeId, linksMatrix);

--- a/src/components/graph/graph.helper.js
+++ b/src/components/graph/graph.helper.js
@@ -33,7 +33,6 @@ import DEFAULT_CONFIG from "./graph.config";
 import ERRORS from "../../err";
 
 import { isDeepEqual, isEmptyObject, merge, pick, antiPick, throwErr, logWarning } from "../../utils";
-import { computeNodeDegree } from "./collapse.helper";
 
 const NODE_PROPS_WHITELIST = ["id", "highlighted", "x", "y", "index", "vy", "vx"];
 const LINK_PROPS_WHITELIST = ["index", "source", "target", "isHidden"];
@@ -199,11 +198,8 @@ function _mergeDataLinkWithD3Link(link, index, d3Links = [], config, state = {})
  */
 function _tagOrphanNodes(nodes, linksMatrix) {
   return Object.keys(nodes).reduce((acc, nodeId) => {
-    const { inDegree, outDegree } = computeNodeDegree(nodeId, linksMatrix);
     const node = nodes[nodeId];
-    const taggedNode = inDegree === 0 && outDegree === 0 ? { ...node, _orphan: true } : node;
-
-    acc[nodeId] = taggedNode;
+    acc[nodeId] = linksMatrix[nodeId] ? node : { ...node, _orphan: true };
 
     return acc;
   }, {});
@@ -594,4 +590,5 @@ export {
   getNormalizedNodeCoordinates,
   initializeNodes,
   isPositionInBounds,
+  _tagOrphanNodes,
 };


### PR DESCRIPTION
(Currently making fixes to this PR to pass tests)

This PR fixes a bug where orphan nodes would sometimes reappear or remain visible in collapsible graphs.

An easy way to reproduce the bug in sandbox:
1. Select "collapsible" checkbox in the graph configuration
2. Click on a parent node to hide its children
3. Click on "Generate Config" button (may have to click multiple times). The hidden child nodes will reappear and no longer disappear when you click on their parent nodes.