### PR TITLE
Add d3-drag fixing next.js error #1

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "peerDependencies": {
     "d3": "^5.5.0",
+    "d3-drag": "^3.0.0",
     "react": "^16.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
When I tried to use this library with next.js 13+ I got the following error: 
```
./node_modules/react-d3-graph/lib/components/graph/Graph.js:10:0 
Module not found: Can't resolve 'd3-drag'
```

Manually installing this dependency inside the package (node_modules/react-d3-graph) fixes it. I'm not sure wheter it is the best solution.

More details in the issue:
danielcaldas#556